### PR TITLE
Naive Paging Plugin Implemented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = riscv64-unknown-linux-gnu-gcc
 CFLAGS = -Wall -Werror -fPIC -fno-builtin $(OPTIONS_FLAGS)
-SRCS = boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c
+SRCS = boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c
 ASM_SRCS = entry.S
 RUNTIME = eyrie-rt
 LINK = riscv64-unknown-linux-gnu-ld

--- a/boot.c
+++ b/boot.c
@@ -9,6 +9,7 @@
 #include "freemem.h"
 #include "mm.h"
 #include "env.h"
+#include "paging.h"
 
 /* defined in vm.h */
 extern uintptr_t shared_buffer;
@@ -23,74 +24,6 @@ extern void* encl_trap_handler;
 
 #ifdef USE_FREEMEM
 
-void
-map_physical_memory_with_megapages(uintptr_t dram_base,
-                                   uintptr_t dram_size,
-                                   uintptr_t ptr)
-{
-  uintptr_t offset = 0;
-
-  /* we're gonna use L2 mega pages, so the memory
-   * is supposed to be smaller than a gigapage */
-  assert(dram_size <= RISCV_GET_LVL_PGSIZE(1));
-
-  /* if the enclave memory is larger than a megapage,
-   * it is supposed to be aligned with a megapage */
-  assert(IS_ALIGNED(dram_base, RISCV_GET_LVL_PGSIZE_BITS(2)));
-
-  /* the starting VA must be aligned with a gigapage so that
-   * we can use all entries of an L2 page table */
-  assert(IS_ALIGNED(ptr, RISCV_GET_LVL_PGSIZE_BITS(1)));
-
-  /* root page table */
-  root_page_table[RISCV_GET_PT_INDEX(ptr, 1)] =
-    ptd_create(ppn(kernel_va_to_pa(load_l2_page_table)));
-
-  /* map megapages */
-  for (offset = 0;
-       offset < dram_size;
-       offset += RISCV_GET_LVL_PGSIZE(2))
-  {
-    load_l2_page_table[RISCV_GET_PT_INDEX(ptr + offset, 2)] =
-      pte_create(ppn(dram_base + offset),
-          PTE_R | PTE_W | PTE_X | PTE_A | PTE_D);
-  }
-}
-
-void
-map_physical_memory_with_kilopages(uintptr_t dram_base,
-                                   uintptr_t dram_size,
-                                   uintptr_t ptr)
-{
-  uintptr_t offset = 0;
-
-  assert(dram_size <= RISCV_GET_LVL_PGSIZE(2));
-
-  /* the memory is supposed to be aligned with a 4K page */
-  assert(IS_ALIGNED(dram_base, RISCV_GET_LVL_PGSIZE_BITS(3)));
-
-  /* the starting VA must be aligned with a megapage so that
-   * we can use all entries of a last-level page table */
-  assert(IS_ALIGNED(ptr, RISCV_GET_LVL_PGSIZE_BITS(2)));
-
-  /* root page table */
-  root_page_table[RISCV_GET_PT_INDEX(ptr, 1)] =
-    ptd_create(ppn(kernel_va_to_pa(load_l2_page_table)));
-
-  /* l2 page table */
-  load_l2_page_table[RISCV_GET_PT_INDEX(ptr, 2)] =
-    ptd_create(ppn(kernel_va_to_pa(load_l3_page_table)));
-
-  /* map pages */
-  for (offset = 0;
-       offset < dram_size;
-       offset += RISCV_GET_LVL_PGSIZE(3))
-  {
-    load_l3_page_table[RISCV_GET_PT_INDEX(ptr + offset, 3)] =
-      pte_create(ppn(dram_base + offset),
-          PTE_R | PTE_W | PTE_X | PTE_A | PTE_D);
-  }
-}
 
 /* map entire enclave physical memory so that
  * we can access the old page table and free memory */
@@ -102,38 +35,19 @@ map_physical_memory(uintptr_t dram_base,
   uintptr_t ptr = EYRIE_LOAD_START;
   /* load address should not override kernel address */
   assert(RISCV_GET_PT_INDEX(ptr, 1) != RISCV_GET_PT_INDEX(runtime_va_start, 1));
-
-  if (dram_size > RISCV_GET_LVL_PGSIZE(2))
-    map_physical_memory_with_megapages(dram_base, dram_size, ptr);
-  else
-    map_physical_memory_with_kilopages(dram_base, dram_size, ptr);
+  map_with_reserved_page_table(dram_base, dram_size,
+      ptr, load_l2_page_table, load_l3_page_table);
 }
 
 void
 remap_kernel_space(uintptr_t runtime_base,
                    uintptr_t runtime_size)
 {
-  uintptr_t offset;
-
   /* eyrie runtime is supposed to be smaller than a megapage */
   assert(runtime_size <= RISCV_GET_LVL_PGSIZE(2));
 
-  /* root page table */
-  root_page_table[RISCV_GET_PT_INDEX(runtime_va_start, 1)] =
-    ptd_create(ppn(kernel_va_to_pa(kernel_l2_page_table)));
-
-  /* L2 page talbe */
-  kernel_l2_page_table[RISCV_GET_PT_INDEX(runtime_va_start, 2)] =
-    ptd_create(ppn(kernel_va_to_pa(kernel_l3_page_table)));
-
-  for (offset = 0;
-       offset < runtime_size;
-       offset += RISCV_GET_LVL_PGSIZE(3))
-  {
-    kernel_l3_page_table[RISCV_GET_PT_INDEX(runtime_va_start + offset, 3)] =
-      pte_create(ppn(runtime_base + offset),
-          PTE_R | PTE_W | PTE_X | PTE_A | PTE_D);
-  }
+  map_with_reserved_page_table(runtime_base, runtime_size,
+     runtime_va_start, kernel_l2_page_table, kernel_l3_page_table);
 }
 
 void
@@ -226,6 +140,9 @@ eyrie_boot(uintptr_t dummy, // $a0 contains the return value from the SBI
   //highest used addr. Instead we start partway through the anon space
   set_program_break(EYRIE_ANON_REGION_START + (1024 * 1024 * 1024));
 
+  #ifdef USE_PAGING
+  init_paging();
+  #endif /* USE_PAGING */
 #endif /* USE_FREEMEM */
 
   /* initialize user stack */

--- a/boot.c
+++ b/boot.c
@@ -112,16 +112,20 @@ eyrie_boot(uintptr_t dummy, // $a0 contains the return value from the SBI
            uintptr_t utm_vaddr,
            uintptr_t utm_size)
 {
-
   /* set initial values */
   load_pa_start = dram_base;
   shared_buffer = utm_vaddr;
   shared_buffer_size = utm_size;
   runtime_va_start = (uintptr_t) &rt_base;
   kernel_offset = runtime_va_start - runtime_paddr;
+
+  debug("UTM : 0x%lx-0x%lx (%u KB)", utm_vaddr, utm_vaddr+utm_size, utm_size/1024);
+  debug("DRAM: 0x%lx-0x%lx (%u KB)", dram_base, dram_base + dram_size, dram_size/1024);
 #ifdef USE_FREEMEM
   freemem_va_start = __va(free_paddr);
   freemem_size = dram_base + dram_size - free_paddr;
+
+  debug("FREE: 0x%lx-0x%lx (%u KB), va 0x%lx", free_paddr, dram_base + dram_size, freemem_size/1024, freemem_va_start);
 
   /* remap kernel VA */
   remap_kernel_space(runtime_paddr, user_paddr - runtime_paddr);
@@ -160,6 +164,7 @@ eyrie_boot(uintptr_t dummy, // $a0 contains the return value from the SBI
   /* Enable the FPU */
   csr_write(sstatus, csr_read(sstatus) | 0x6000);
 
+  debug("eyrie boot finished. drop to the user land ...");
   /* booting all finished, droping to the user land */
   return;
 }

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,9 @@ for plugin in $PLUGINS; do
     freemem)
       OPTIONS_FLAGS+="-DUSE_FREEMEM "
       ;;
+    paging)
+      OPTIONS_FLAGS+="-DUSE_PAGING "
+      ;;
     untrusted_io_syscall)
       OPTIONS_FLAGS+="-DIO_SYSCALL_WRAPPING "
       ;;

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,8 @@ PLUGINS[untrusted_io_syscall]="-DIO_SYSCALL_WRAPPING "
 PLUGINS[linux_syscall]="-DLINUX_SYSCALL_WRAPPING "
 PLUGINS[env_setup]="-DENV_SETUP "
 PLUGINS[strace_debug]="-DINTERNAL_STRACE "
-PLUGINS[paging]="-DUSE_PAGING "
+PLUGINS[paging]="-DUSE_PAGING -DUSE_FREEMEM "
+PLUGINS[debug]="-DDEBUG "
 #PLUGINS[dynamic_resizing]="-DDYN_ALLOCATION "
 
 OPTIONS_FLAGS=

--- a/common.h
+++ b/common.h
@@ -1,12 +1,41 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
+#include <stdbool.h>
 #include "sbi.h"
 #include "printf.h"
+
+#define RISCV_EXCP_INST_MISALIGNED  0
+#define RISCV_EXCP_INST_FAULT       1
+#define RISCV_EXCP_ILLEGAL_INST     2
+#define RISCV_EXCP_BREAKPOINT       3
+#define RISCV_EXCP_LOAD_MISALIGNED  4
+#define RISCV_EXCP_LOAD_FAULT       5
+#define RISCV_EXCP_STORE_MISALIGNED 6
+#define RISCV_EXCP_STORE_FAULT      7
+#define RISCV_EXCP_ECALL_U          8
+#define RISCV_EXCP_ECALL_S          9
+// reserved                         10
+#define RISCV_EXCP_ECALL_M          11
+#define RISCV_EXCP_INST_PAGE_FAULT  12
+#define RISCV_EXCP_LOAD_PAGE_FAULT  13
+// reserved                         14
+#define RISCV_EXCP_STORE_PAGE_FAULT 15
 
 #define assert(x) \
   if(!(x)) { printf("assertion failed at %s:%d\n", __FILE__, __LINE__);\
     sbi_exit_enclave(-1); \
   }
+
+#ifdef DEBUG
+#define debug(format, ...) \
+  printf ("[debug] " format "(%s:%d)", ## __VA_ARGS__, __FILE__, __LINE__)
+#else
+#define debug(x, format, ...) \
+  ;
+#endif
+
+#define warn(format, ...) \
+  printf ("[warn] " format "(%s:%d)", ## __VA_ARGS__, __FILE__, __LINE__)
 
 #endif

--- a/common.h
+++ b/common.h
@@ -23,19 +23,19 @@
 #define RISCV_EXCP_STORE_PAGE_FAULT 15
 
 #define assert(x) \
-  if(!(x)) { printf("assertion failed at %s:%d\n", __FILE__, __LINE__);\
+  if(!(x)) { printf("assertion failed at %s:%d\r\n", __FILE__, __LINE__);\
     sbi_exit_enclave(-1); \
   }
 
 #ifdef DEBUG
 #define debug(format, ...) \
-  printf ("[debug] " format "(%s:%d)", ## __VA_ARGS__, __FILE__, __LINE__)
+  printf ("[debug] " format " (%s:%d)\r\n", ## __VA_ARGS__, __FILE__, __LINE__)
 #else
-#define debug(x, format, ...) \
+#define debug(format, ...) \
   ;
 #endif
 
 #define warn(format, ...) \
-  printf ("[warn] " format "(%s:%d)", ## __VA_ARGS__, __FILE__, __LINE__)
+  printf ("[warn] " format " (%s:%d)\r\n", ## __VA_ARGS__, __FILE__, __LINE__)
 
 #endif

--- a/entry.S
+++ b/entry.S
@@ -12,6 +12,7 @@
 //entry point to the runtime!
 .altmacro
 .macro SAVE_ALL_BUT_SP
+  addi sp, sp, -ENCL_CONTEXT_SIZE
   STORE ra, 1*REGBYTES(sp)
   STORE gp, 3*REGBYTES(sp)
   STORE tp, 4*REGBYTES(sp)
@@ -110,6 +111,7 @@
   LOAD t4, 29*REGBYTES(sp)
   LOAD t5, 30*REGBYTES(sp)
   LOAD t6, 31*REGBYTES(sp)
+  addi sp, sp, ENCL_CONTEXT_SIZE
 .endm
 
 _start:
@@ -132,14 +134,16 @@ encl_trap_handler:
 /* TODO we may want to explicitly disable the FPU here ala linux */
 
   csrrw sp, sscratch, sp
+  bnez sp, __save_context
+  /* if trap is from kernel, restore sp */
+  csrr sp, sscratch
 
-  addi sp, sp, -ENCL_CONTEXT_SIZE
-
-  /* save enclave context */
+__save_context:
+  /* save previous context */
   SAVE_ALL_BUT_SP
 
-  csrrw t0, sscratch, x0           # t0 <- user sp
-  STORE t0, 2*REGBYTES(sp)         # user sp
+  csrrw t0, sscratch, x0           # t0 <- previous sp
+  STORE t0, 2*REGBYTES(sp)         # previous sp
 
   csrr t0, sepc
   STORE t0, (sp)
@@ -197,8 +201,6 @@ return_to_encl:
 
   RESTORE_ALL_BUT_SP
 
-  addi sp, sp, ENCL_CONTEXT_SIZE
-
   csrrw sp, sscratch, sp
   sret
 
@@ -207,8 +209,9 @@ not_implemented:
   li a7, 1111
   ecall
 
-  .section ".rodata"
+  .section ".data"
 rt_trap_table:
+  .global rt_trap_table
   .align 6
   .dword not_implemented_fatal //0
   .dword not_implemented_fatal //1

--- a/freemem.c
+++ b/freemem.c
@@ -2,6 +2,7 @@
 #include "common.h"
 #include "vm.h"
 #include "freemem.h"
+#include "paging.h"
 
 /* This file implements a simple page allocator (SPA)
  * which stores the pages based on a linked list.
@@ -18,13 +19,29 @@ static struct pg_list spa_free_pages;
 
 /* get a free page from the simple page allocator */
 uintptr_t
-spa_get(void)
+__spa_get(bool no_fail)
 {
   uintptr_t free_page;
 
   if (LIST_EMPTY(spa_free_pages)) {
-    printf("eyrie simple page allocator runs out of free pages %s","\n");
-    return 0;
+    if (no_fail) {
+      warn("eyrie simple page allocator runs out of free pages");
+      return 0;
+    }
+
+    /* try evict a page */
+#ifdef USE_PAGING
+    uintptr_t new_pa = paging_evict_and_free_one(0);
+    if(new_pa)
+    {
+      spa_put(__va(new_pa));
+    }
+    else
+#endif
+    {
+      warn("eyrie simple page allocator cannot evict and free pages");
+      return 0;
+    }
   }
 
   free_page = spa_free_pages.head;
@@ -38,6 +55,18 @@ spa_get(void)
   return free_page;
 }
 
+uintptr_t
+spa_get_no_fail(void)
+{
+  return __spa_get(true);
+}
+
+uintptr_t
+spa_get(void)
+{
+  return __spa_get(false);
+}
+
 /* put a page to the simple page allocator */
 void
 spa_put(uintptr_t page_addr)
@@ -45,7 +74,7 @@ spa_put(uintptr_t page_addr)
   uintptr_t prev;
 
   assert(IS_ALIGNED(page_addr, RISCV_PAGE_BITS));
-  assert(page_addr >= freemem_va_start && page_addr < (freemem_va_start  + freemem_size));
+  assert(page_addr >= EYRIE_LOAD_START && page_addr < (freemem_va_start  + freemem_size));
 
   if (!LIST_EMPTY(spa_free_pages)) {
     prev = spa_free_pages.tail;

--- a/freemem.c
+++ b/freemem.c
@@ -19,7 +19,7 @@ static struct pg_list spa_free_pages;
 
 /* get a free page from the simple page allocator */
 uintptr_t
-spa_get()
+__spa_get(bool zero)
 {
   uintptr_t free_page;
 
@@ -47,8 +47,16 @@ spa_get()
   spa_free_pages.head = next;
   spa_free_pages.count--;
 
+  assert(free_page > EYRIE_LOAD_START && free_page < (freemem_va_start + freemem_size));
+
+  if (zero)
+    memset((void*)free_page, 0, RISCV_PAGE_SIZE);
+
   return free_page;
 }
+
+uintptr_t spa_get() { return __spa_get(false); }
+uintptr_t spa_get_zero() { return __spa_get(true); }
 
 /* put a page to the simple page allocator */
 void

--- a/freemem.h
+++ b/freemem.h
@@ -16,6 +16,7 @@ struct pg_list
 
 void spa_init(uintptr_t base, size_t size);
 uintptr_t spa_get(void);
+uintptr_t spa_get_zero(void);
 void spa_put(uintptr_t page);
 unsigned int spa_available();
 #endif

--- a/freemem.h
+++ b/freemem.h
@@ -16,7 +16,6 @@ struct pg_list
 
 void spa_init(uintptr_t base, size_t size);
 uintptr_t spa_get(void);
-uintptr_t spa_get_no_fail(void);
 void spa_put(uintptr_t page);
 unsigned int spa_available();
 #endif

--- a/freemem.h
+++ b/freemem.h
@@ -16,6 +16,7 @@ struct pg_list
 
 void spa_init(uintptr_t base, size_t size);
 uintptr_t spa_get(void);
+uintptr_t spa_get_no_fail(void);
 void spa_put(uintptr_t page);
 unsigned int spa_available();
 #endif

--- a/mm.c
+++ b/mm.c
@@ -24,7 +24,7 @@ void set_program_break(uintptr_t new_break){
 static pte*
 __continue_walk_create(pte* root, uintptr_t addr, pte* pte)
 {
-  uintptr_t new_page = spa_get();
+  uintptr_t new_page = spa_get_zero();
   assert(new_page);
 
   unsigned long free_ppn = ppn(__pa(new_page));
@@ -78,7 +78,6 @@ remap_physical_page(uintptr_t vpn, uintptr_t ppn, int flags)
     return 0;
 
   *pte = pte_create(ppn, flags);
-  tlb_flush();
 
   return (vpn << RISCV_PAGE_BITS);
 }
@@ -121,7 +120,6 @@ alloc_page(uintptr_t vpn, int flags)
   assert(page);
 
   *pte = pte_create(ppn(__pa(page)), flags | PTE_V);
-  tlb_flush();
 
   return page;
 }
@@ -139,7 +137,6 @@ free_page(uintptr_t vpn){
   // Mark invalid
   // TODO maybe do more here
   *pte = (*pte & (~PTE_V));
-  tlb_flush();
 
   // Return phys page
   spa_put(__va(ppn << RISCV_PAGE_BITS));
@@ -250,7 +247,6 @@ __map_with_reserved_page_table(uintptr_t dram_base,
       pte_create(ppn(dram_base + offset),
           PTE_R | PTE_W | PTE_X | PTE_A | PTE_D);
   }
-  tlb_flush();
 }
 
 void

--- a/mm.c
+++ b/mm.c
@@ -1,13 +1,7 @@
-
-
 #include "common.h"
 #include "syscall.h"
 #include "mm.h"
 #include "freemem.h"
-#include "vm.h"
-
-
-
 
 #ifdef USE_FREEMEM
 
@@ -29,7 +23,9 @@ void set_program_break(uintptr_t new_break){
 static pte*
 __continue_walk_create(pte* root, uintptr_t addr, pte* pte)
 {
-  uintptr_t new_page = spa_get();
+  uintptr_t new_page = spa_get_no_fail();
+  assert(new_page);
+
   unsigned long free_ppn = ppn(__pa(new_page));
   *pte = ptd_create(free_ppn);
   return __walk_create(root, addr);
@@ -120,6 +116,8 @@ alloc_page(uintptr_t vpn, int flags)
 
 	/* otherwise, allocate one from the freemem */
   page = spa_get();
+  assert(page);
+
   *pte = pte_create(ppn(__pa(page)), flags | PTE_V);
 
   return page;
@@ -195,10 +193,72 @@ translate(uintptr_t va)
 {
   pte* pte = __walk(root_page_table, va);
 
-  if(*pte & PTE_V)
+  if(pte && (*pte & PTE_V))
     return (pte_ppn(*pte) << RISCV_PAGE_BITS) | (RISCV_PAGE_OFFSET(va));
   else
     return 0;
+}
+
+/* try to retrieve PTE for a VA, return 0 if fail */
+pte*
+pte_of_va(uintptr_t va)
+{
+  pte* pte = __walk(root_page_table, va);
+  return pte;
+}
+
+void
+__map_with_reserved_page_table(uintptr_t dram_base,
+                               uintptr_t dram_size,
+                               uintptr_t ptr,
+                               pte* l2_pt,
+                               pte* l3_pt)
+{
+  uintptr_t offset = 0;
+  uintptr_t leaf_level = 3;
+  pte* leaf_pt = l3_pt;
+  /* use megapage if l3_pt is null */
+  if (!l3_pt) {
+    leaf_level = 2;
+    leaf_pt = l2_pt;
+  }
+
+  assert(dram_size <= RISCV_GET_LVL_PGSIZE(leaf_level - 1));
+  assert(IS_ALIGNED(dram_base, RISCV_GET_LVL_PGSIZE_BITS(leaf_level)));
+  assert(IS_ALIGNED(ptr, RISCV_GET_LVL_PGSIZE_BITS(leaf_level - 1)));
+
+  /* set root page table entry */
+  root_page_table[RISCV_GET_PT_INDEX(ptr, 1)] =
+    ptd_create(ppn(kernel_va_to_pa(l2_pt)));
+
+  /* set L2 if it's not leaf */
+  if (leaf_pt != l2_pt) {
+    l2_pt[RISCV_GET_PT_INDEX(ptr, 2)] =
+      ptd_create(ppn(kernel_va_to_pa(l3_pt)));
+  }
+
+  /* set leaf level */
+  for (offset = 0;
+       offset < dram_size;
+       offset += RISCV_GET_LVL_PGSIZE(leaf_level))
+  {
+    leaf_pt[RISCV_GET_PT_INDEX(ptr + offset, leaf_level)] =
+      pte_create(ppn(dram_base + offset),
+          PTE_R | PTE_W | PTE_X | PTE_A | PTE_D);
+  }
+}
+
+void
+map_with_reserved_page_table(uintptr_t dram_base,
+                             uintptr_t dram_size,
+                             uintptr_t ptr,
+                             pte* l2_pt,
+                             pte* l3_pt)
+{
+  if (dram_size > RISCV_GET_LVL_PGSIZE(2))
+    __map_with_reserved_page_table(dram_base, dram_size, ptr, l2_pt, 0);
+  else
+    __map_with_reserved_page_table(dram_base, dram_size, ptr, l2_pt, l3_pt);
 }
 
 #endif /* USE_FREEMEM */

--- a/mm.h
+++ b/mm.h
@@ -2,9 +2,10 @@
 #define _MM_H_
 #include <stdint.h>
 #include <stddef.h>
+#include "vm.h"
 
 uintptr_t translate(uintptr_t va);
-
+pte* pte_of_va(uintptr_t va);
 #ifdef USE_FREEMEM
 uintptr_t remap_physical_page(uintptr_t vpn, uintptr_t ppn, int flags);
 size_t remap_physical_pages(uintptr_t vpn, uintptr_t ppn, size_t count, int flags);
@@ -17,6 +18,8 @@ size_t test_va_range(uintptr_t vpn, size_t count);
 
 uintptr_t get_program_break();
 void set_program_break(uintptr_t new_break);
+
+void map_with_reserved_page_table(uintptr_t base, uintptr_t size, uintptr_t ptr, pte* l2_pt, pte* l3_pt);
 #endif /* USE_FREEMEM */
 
 #endif /* _MM_H_ */

--- a/paging.c
+++ b/paging.c
@@ -199,8 +199,6 @@ void __swap_epm_page(uintptr_t back_page, uintptr_t epm_page, uintptr_t swap_pag
   if (swap_page) {
     memcpy((void*)epm_page, buffer, RISCV_PAGE_SIZE);
   }
-  else
-  { memset((void*)epm_page, 0, RISCV_PAGE_SIZE); }
 
   return;
 }
@@ -288,7 +286,6 @@ void paging_handle_page_fault(struct encl_ctx* ctx)
   /* validate the entry */
   *entry = pte_create(ppn(frame), *entry & PTE_FLAG_MASK);
 
-  tlb_flush();
   return;
 exit:
   warn("fatal paging failure");

--- a/paging.c
+++ b/paging.c
@@ -1,0 +1,284 @@
+#if defined(USE_PAGING) && !defined(USE_FREEMEM)
+#error "paging requires freemem"
+#endif
+
+#if defined(USE_FREEMEM) && defined(USE_PAGING)
+
+#include "paging.h"
+
+uintptr_t paging_backing_storage_addr;
+uintptr_t paging_backing_storage_size;
+uintptr_t paging_next_backing_page_offset;
+
+extern uintptr_t rt_trap_table;
+
+uintptr_t __alloc_backing_page()
+{
+  uintptr_t next_page;
+
+  /* no backing page available */
+  if (paging_next_backing_page_offset >= paging_backing_storage_size) {
+    return 0;
+  }
+
+  next_page = paging_backing_storage_addr + paging_next_backing_page_offset;
+  assert(IS_ALIGNED(next_page, RISCV_PAGE_BITS));
+
+  paging_next_backing_page_offset += RISCV_PAGE_SIZE;
+
+  return next_page;
+}
+
+void init_paging()
+{
+  uintptr_t addr;
+  uintptr_t size;
+  uintptr_t* trap_table = &rt_trap_table;
+
+  /* query if there is backing store */
+  size = sbi_query_multimem();
+
+  if (!size) {
+		warn("no backing store found\n");
+    return;
+  }
+
+  /* query the backing store PA */
+  addr = sbi_query_multimem_addr();
+
+  if (!addr) {
+		warn("address is zero\n");
+    return;
+  }
+
+  paging_pa_start = addr;
+  paging_backing_storage_size = size;
+  paging_backing_storage_addr = __paging_va(addr);
+  paging_next_backing_page_offset = 0;
+
+  /* create VA mapping, we don't give execution perm */
+  remap_physical_pages(vpn(EYRIE_PAGING_START),
+                       ppn(addr), size >> RISCV_PAGE_BITS,
+                       PTE_R | PTE_W | PTE_D | PTE_A);
+
+  /* register page fault handler */
+  trap_table[RISCV_EXCP_INST_PAGE_FAULT] = (uintptr_t) paging_handle_page_fault;
+  trap_table[RISCV_EXCP_LOAD_PAGE_FAULT] = (uintptr_t) paging_handle_page_fault;
+  trap_table[RISCV_EXCP_STORE_PAGE_FAULT] = (uintptr_t) paging_handle_page_fault;
+
+  return;
+}
+
+uintptr_t
+__traverse_page_table_and_pick_internal(
+    int level,
+    pte* tb,
+    uintptr_t vaddr,
+    uintptr_t count)
+{
+  pte* walk;
+  int i=0;
+  uintptr_t next_count = count;
+
+  for (walk=tb, i=0;
+       walk < tb + (RISCV_PAGE_SIZE/sizeof(pte));
+       walk += 1, i++)
+  {
+    if(*walk == 0)
+      continue;
+
+    pte entry = *walk;
+    uintptr_t phys_addr = pte_ppn(entry) << RISCV_PAGE_BITS;
+    uintptr_t virt_addr = ((vaddr << RISCV_PT_INDEX_BITS) | (i&0x1ff))<<RISCV_PAGE_BITS;
+
+    /* if this is a leaf */
+    if(level == 1 ||
+        (entry & PTE_R) || (entry & PTE_W) || (entry & PTE_X))
+    {
+      if ((entry & PTE_U) && (entry & PTE_V))
+      {
+        next_count--;
+      }
+
+      if (next_count == 0)
+        return virt_addr;
+    }
+    else
+    {
+      uintptr_t ret;
+
+      /* extending MSB */
+      if(level == 3 && (i&0x100))
+        vaddr = 0xffffffffffffffffUL;
+
+      ret = __traverse_page_table_and_pick_internal(
+          level - 1,
+          (pte*) __va(phys_addr),
+          vpn(virt_addr),
+          next_count);
+      if (ret)
+        return ret;
+    }
+  }
+
+  return 0;
+}
+
+uintptr_t
+__traverse_page_table_and_pick(uintptr_t count)
+{
+  return __traverse_page_table_and_pick_internal(
+      RISCV_PT_LEVELS, root_page_table, 0, count);
+}
+
+/* pick a virtual page to evict
+ * at this moment, we randomly choose a user page
+ * return: va of a page mapped to user
+ *         0 if failed */
+uintptr_t __pick_page()
+{
+  uintptr_t target = 0;
+  int max_retry = 3;
+  int try = 0;
+
+  while (try < max_retry)
+  {
+    uintptr_t rnd;
+    uintptr_t count, candidate_va;
+    uintptr_t frame_count = freemem_size >> RISCV_PAGE_BITS;
+
+    assert(frame_count > 0);
+
+    rnd = sbi_random();
+    assert(rnd != 0);
+    count = (rnd % frame_count) + 1;
+    candidate_va = __traverse_page_table_and_pick(count);
+
+    if (candidate_va) {
+      target = candidate_va;
+      break;
+    }
+
+    try++;
+  }
+
+  return target;
+}
+
+/* evict a page from EPM and store it to the backing storage
+ * back_page (PA1) <-- epm_page (PA2) <-- swap_page (PA1)
+ * if swap_page is 0, no need to write epm_page
+ */
+void __swap_epm_page(uintptr_t back_page, uintptr_t epm_page, uintptr_t swap_page, bool encrypt)
+{
+  assert(epm_page >= EYRIE_LOAD_START);
+  assert(epm_page < freemem_va_start + freemem_size);
+  assert(back_page >= paging_backing_storage_addr);
+  assert(back_page < paging_backing_storage_addr + paging_backing_storage_size);
+
+  /* not implemented */
+  assert(!encrypt);
+
+  char buffer[RISCV_PAGE_SIZE] = {0,};
+  if (swap_page) {
+    assert(swap_page == back_page);
+    memcpy(buffer, (void*)swap_page, RISCV_PAGE_SIZE);
+  }
+
+  memcpy((void*)back_page, (void*)epm_page, RISCV_PAGE_SIZE);
+
+  if (swap_page) {
+    memcpy((void*)epm_page, buffer, RISCV_PAGE_SIZE);
+  }
+
+  return;
+}
+
+/* pick a user page, evict, and put it to the freemem
+ * input: backing store addr (va)
+ *        0 if new
+ * return: loaded frame address (pa)
+ *        0 if failed */
+uintptr_t paging_evict_and_free_one(uintptr_t swap_va)
+{
+  /* pick a valid page */
+  uintptr_t target_va, dest_va, src_pa;
+  pte* target_pte;
+
+  target_va = __pick_page();
+
+  if(!target_va) {
+    warn("**** failed to pick frame to evict");
+    return 0;
+  }
+
+  /* find the destination to swap out */
+  if(swap_va)
+    dest_va = swap_va;
+  else
+    dest_va = __alloc_backing_page();
+
+  assert(dest_va >= paging_backing_storage_addr);
+  assert(dest_va < paging_backing_storage_addr +
+                   paging_backing_storage_size);
+
+  /* evict & load */
+  target_pte = pte_of_va(target_va);
+  assert(target_pte);
+
+  src_pa = pte_ppn(*target_pte) << RISCV_PAGE_BITS;
+  __swap_epm_page(dest_va, __va(src_pa), swap_va, false);
+
+  /* invalidate target PTE */
+  *target_pte = pte_create_invalid(ppn(__paging_pa(dest_va)),
+      *target_pte & PTE_FLAG_MASK);
+
+  return src_pa;
+}
+
+void paging_handle_page_fault(struct encl_ctx* ctx)
+{
+  uintptr_t addr;
+  uintptr_t back_ptr;
+  uintptr_t frame;
+  pte* entry;
+
+  addr = ctx->sbadaddr;
+
+  /* VA legitimacy check */
+  if (addr >= EYRIE_LOAD_START)
+    goto exit;
+
+  entry = pte_of_va(addr);
+
+  /* VA is never mapped, exit */
+  if (!entry)
+    goto exit;
+
+  /* if PTE is already valid, it means something went wrong */
+  if (*entry & PTE_V)
+    goto exit;
+
+  /* where is the page? */
+  back_ptr = __paging_va(pte_ppn(*entry) << RISCV_PAGE_BITS);
+  if (!back_ptr)
+    goto exit;
+
+  assert(back_ptr >= paging_backing_storage_addr);
+  assert(back_ptr < paging_backing_storage_addr + paging_backing_storage_size);
+
+  /* evict & swap */
+  frame = paging_evict_and_free_one(back_ptr);
+  if (!frame)
+    goto exit;
+
+  /* validate the entry */
+  *entry = pte_create(ppn(frame), *entry & PTE_FLAG_MASK);
+
+  return;
+exit:
+  warn("fatal paging failure");
+  rt_page_fault(ctx);
+}
+
+#endif //USE_FREEMEM

--- a/paging.h
+++ b/paging.h
@@ -1,0 +1,35 @@
+#if defined(USE_FREEMEM) && defined(USE_PAGING)
+
+#ifndef __PAGING_H__
+#define __PAGING_H__
+
+#include <stdint.h>
+#include "printf.h"
+#include "regs.h"
+#include "common.h"
+#include "vm.h"
+#include "mm.h"
+#include "freemem.h"
+#include "string.h"
+#include "rt_util.h"
+
+void init_paging();
+void paging_handle_page_fault(struct encl_ctx* ctx);
+uintptr_t paging_evict_and_free_one(uintptr_t swap_va);
+uintptr_t paging_pa_start;
+
+pte paging_l2_page_table[BIT(RISCV_PT_INDEX_BITS)] __attribute__((aligned(RISCV_PAGE_SIZE)));
+pte paging_l3_page_table[BIT(RISCV_PT_INDEX_BITS)] __attribute__((aligned(RISCV_PAGE_SIZE)));
+/* page tables for loading physical memory */
+static inline uintptr_t __paging_pa(uintptr_t va)
+{
+  return (va - EYRIE_PAGING_START) + paging_pa_start;
+}
+
+static inline uintptr_t __paging_va(uintptr_t pa)
+{
+  return (pa - paging_pa_start) + EYRIE_PAGING_START;
+}
+
+#endif
+#endif

--- a/paging.h
+++ b/paging.h
@@ -13,6 +13,7 @@
 #include "string.h"
 #include "rt_util.h"
 
+unsigned int paging_remaining_pages(void);
 void init_paging();
 void paging_handle_page_fault(struct encl_ctx* ctx);
 uintptr_t paging_evict_and_free_one(uintptr_t swap_va);

--- a/rt_util.c
+++ b/rt_util.c
@@ -71,5 +71,5 @@ void rt_page_fault(struct encl_ctx* ctx)
 
 void tlb_flush(void)
 {
-  asm volatile ("sfence.vma\t\n");
+  asm volatile ("fence.i\t\nsfence.vma\t\n");
 }

--- a/rt_util.c
+++ b/rt_util.c
@@ -68,3 +68,8 @@ void rt_page_fault(struct encl_ctx* ctx)
   assert(false);
   return;
 }
+
+void tlb_flush(void)
+{
+  asm volatile ("sfence.vma\t\n");
+}

--- a/rt_util.c
+++ b/rt_util.c
@@ -18,14 +18,14 @@ size_t rt_util_getrandom(void* vaddr, size_t buflen){
   uintptr_t* next = (uintptr_t*)vaddr;
   // Get data
   while(remaining > sizeof(uintptr_t)){
-    rnd = SBI_CALL_0(SBI_SM_RANDOM);
+    rnd = sbi_random();
     ALLOW_USER_ACCESS( *next = rnd );
     remaining -= sizeof(uintptr_t);
     next++;
   }
   // Cleanup
   if( remaining > 0 ){
-    rnd = SBI_CALL_0(SBI_SM_RANDOM);
+    rnd = sbi_random();
     copy_to_user(next, &rnd, remaining);
   }
   size_t ret = buflen;
@@ -63,5 +63,8 @@ void rt_page_fault(struct encl_ctx* ctx)
 #endif
 
   sbi_exit_enclave(-1);
+
+  /* never reach here */
+  assert(false);
   return;
 }

--- a/rt_util.h
+++ b/rt_util.h
@@ -10,6 +10,7 @@
 size_t rt_util_getrandom(void* vaddr, size_t buflen);
 void not_implemented_fatal(struct encl_ctx* ctx);
 void rt_util_misc_fatal();
+void rt_page_fault(struct encl_ctx* ctx);
 
 extern unsigned char rt_copy_buffer_1[RISCV_PAGE_SIZE];
 extern unsigned char rt_copy_buffer_2[RISCV_PAGE_SIZE];

--- a/rt_util.h
+++ b/rt_util.h
@@ -11,6 +11,7 @@ size_t rt_util_getrandom(void* vaddr, size_t buflen);
 void not_implemented_fatal(struct encl_ctx* ctx);
 void rt_util_misc_fatal();
 void rt_page_fault(struct encl_ctx* ctx);
+void tlb_flush(void);
 
 extern unsigned char rt_copy_buffer_1[RISCV_PAGE_SIZE];
 extern unsigned char rt_copy_buffer_2[RISCV_PAGE_SIZE];

--- a/sbi.h
+++ b/sbi.h
@@ -19,7 +19,13 @@
 #define SBI_SM_RESUME_ENCLAVE    107
 #define SBI_SM_RANDOM            108
 #define SBI_SM_EXIT_ENCLAVE     1101
+#define SBI_SM_CALL_PLUGIN      1000
 #define SBI_SM_NOT_IMPLEMENTED  1111
+
+/* Plugin IDs and Call IDs */
+#define SM_MULTIMEM_PLUGIN_ID   0x01
+#define SM_MULTIMEM_CALL_GET_SIZE 0x01
+#define SM_MULTIMEM_CALL_GET_ADDR 0x02
 
 #define SBI_CALL(___which, ___arg0, ___arg1, ___arg2) ({			\
 	register uintptr_t a0 asm ("a0") = (uintptr_t)(___arg0);	\
@@ -55,5 +61,20 @@ static inline void sbi_stop_enclave(uint64_t request)
 static inline void sbi_exit_enclave(uint64_t retval)
 {
   SBI_CALL_1(SBI_SM_EXIT_ENCLAVE, retval);
+}
+
+static inline uintptr_t sbi_random()
+{
+  return SBI_CALL_0(SBI_SM_RANDOM);
+}
+
+static inline uintptr_t sbi_query_multimem()
+{
+  return SBI_CALL_2(SBI_SM_CALL_PLUGIN, SM_MULTIMEM_PLUGIN_ID, SM_MULTIMEM_CALL_GET_SIZE);
+}
+
+static inline uintptr_t sbi_query_multimem_addr()
+{
+  return SBI_CALL_2(SBI_SM_CALL_PLUGIN, SM_MULTIMEM_PLUGIN_ID, SM_MULTIMEM_CALL_GET_ADDR);
 }
 #endif

--- a/vm.h
+++ b/vm.h
@@ -24,6 +24,8 @@
 #define ROUND_DOWN(n, b) (n & ~((2 << (b-1)) - 1))
 #define PAGE_DOWN(n) ROUND_DOWN(n, RISCV_PAGE_BITS)
 #define PAGE_UP(n) ROUND_UP(n, RISCV_PAGE_BITS)
+#define MEGAPAGE_DOWN(n) ROUND_DOWN(n, RISCV_GET_LVL_PGSIZE_BITS(2))
+#define MEGAPAGE_UP(n) ROUND_UP(n, RISCV_GET_LVL_PGSIZE_BITS(2))
 
 /* Starting address of the enclave memory */
 #define EYRIE_LOAD_START        0xffffffff00000000

--- a/vm.h
+++ b/vm.h
@@ -1,16 +1,13 @@
 #ifndef __VM_H__
 #define __VM_H__
 
-
 #include <asm/csr.h>
 #include "printf.h"
 #include "common.h"
 
-
 #define BIT(n) (1ul << (n))
 #define MASK(n) (BIT(n)-1ul)
 #define IS_ALIGNED(n, b) (!((n) & MASK(b)))
-
 
 #define RISCV_PT_INDEX_BITS 9
 #define RISCV_PT_LEVELS 3
@@ -30,6 +27,7 @@
 
 /* Starting address of the enclave memory */
 #define EYRIE_LOAD_START        0xffffffff00000000
+#define EYRIE_PAGING_START      0xffffffff40000000
 #define EYRIE_UNTRUSTED_START   0xffffffff80000000
 #define EYRIE_USER_STACK_START  0x0000000040000000
 #define EYRIE_ANON_REGION_START 0x0000002000000000 // Arbitrary VA to start looking for large mappings
@@ -45,6 +43,7 @@
 #define PTE_G     0x020 // Global
 #define PTE_A     0x040 // Accessed
 #define PTE_D     0x080 // Dirty
+#define PTE_FLAG_MASK 0x3ff
 #define PTE_PPN_SHIFT 10
 
 extern void* rt_base;
@@ -76,7 +75,12 @@ static inline uintptr_t __pa(uintptr_t va)
 typedef uintptr_t pte;
 static inline pte pte_create(uintptr_t ppn, int type)
 {
-  return (pte)((ppn << PTE_PPN_SHIFT) | PTE_V | type );
+  return (pte)((ppn << PTE_PPN_SHIFT) | PTE_V | (type & PTE_FLAG_MASK) );
+}
+
+static inline pte pte_create_invalid(uintptr_t ppn, int type)
+{
+  return (pte)((ppn << PTE_PPN_SHIFT) | (type & PTE_FLAG_MASK & ~PTE_V));
 }
 
 static inline pte ptd_create(uintptr_t ppn)


### PR DESCRIPTION
Paging plugin allows the enclave to use back-up memory as a swap space.
When there is not sufficient free memory, the paging plugin will evict
one of the valid user page to free a frame, and allocate the frame.
Page fault handler is hooked when the plugin initializes such that the
evicted page can be loaded on page faults.

Currently, the paging plugin uses random eviction policy, where it picks
a random counter and search for the n-th user page by traversing the page table.

Paging plugin can be compiled with `-DUSE_PAGING` flag, but it also
requires `-DUSE_FREEMEM`.