### PR TITLE
add error if KEYSTONE_SDK_DIR not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 ifndef KEYSTONE_SDK_DIR
   $(error KEYSTONE_SDK_DIR is undefined)
-  exit 1
 endif
 
 CC = riscv64-unknown-linux-gnu-gcc

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+ifndef KEYSTONE_SDK_DIR
+  $(error KEYSTONE_SDK_DIR is undefined)
+  exit 1
+endif
+
 CC = riscv64-unknown-linux-gnu-gcc
 CFLAGS = -Wall -Werror -fPIC -fno-builtin $(OPTIONS_FLAGS)
 SRCS = boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c


### PR DESCRIPTION
Added a condition that returns an error if `KEYSTONE_SDK_DIR` is not set.