### PR TITLE
In-DRAM AES encryption with SHA2 validity checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 CC = riscv64-unknown-linux-gnu-gcc
 OBJCOPY = riscv64-unknown-linux-gnu-objcopy
 CFLAGS = -Wall -Werror -fPIC -fno-builtin -std=c11 -g $(OPTIONS_FLAGS)
-SRCS = aes.c sha256.c boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c sbi.c merkle.c
+SRCS = aes.c sha256.c boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c sbi.c merkle.c page_swap.c
 ASM_SRCS = entry.S
 RUNTIME = eyrie-rt
 LINK = $(CROSS_COMPILE)ld

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 CC = riscv64-unknown-linux-gnu-gcc
 OBJCOPY = riscv64-unknown-linux-gnu-objcopy
 CFLAGS = -Wall -Werror -fPIC -fno-builtin -std=c11 -g $(OPTIONS_FLAGS)
-SRCS = aes.c sha256.c boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c sbi.c
+SRCS = aes.c sha256.c boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c sbi.c merkle.c
 ASM_SRCS = entry.S
 RUNTIME = eyrie-rt
 LINK = $(CROSS_COMPILE)ld
@@ -51,8 +51,8 @@ copy: $(RUNTIME) $(DISK_IMAGE)
 	rm -rf $(MOUNT_DIR)
 
 $(RUNTIME): $(ASM_OBJS) $(OBJS) $(SDK_EDGE_LIB) $(TMPLIB)
-	$(LINK) $(LINKFLAGS) -o $@ $^ -T runtime.lds $(LDFLAGS)
-	$(OBJCOPY) --add-section .options_log=.options_log --set-section-flags .options_log=noload,readonly $(RUNTIME) 
+	$(LINK) -o $@ $^ -T runtime.lds $(LDFLAGS)
+	$(OBJCOPY) --add-section .options_log=.options_log --set-section-flags .options_log=noload,readonly $(RUNTIME)
 
 $(ASM_OBJS): $(ASM_SRCS) $(OBJ_DIR_EXISTS)
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/common.h
+++ b/common.h
@@ -22,6 +22,7 @@
 // reserved                         14
 #define RISCV_EXCP_STORE_PAGE_FAULT 15
 
+#undef assert
 #define assert(x) \
   if(!(x)) { printf("assertion failed at %s:%d\r\n", __FILE__, __LINE__);\
     sbi_exit_enclave(-1); \

--- a/merkle.c
+++ b/merkle.c
@@ -1,0 +1,313 @@
+#if defined(USE_PAGE_HASH)
+
+#include "merkle.h"
+
+#include <assert.h>
+#include <malloc.h>
+#include <string.h>
+
+#include "paging.h"
+#include "sha256.h"
+#include "vm_defs.h"
+
+#ifndef MERK_SILENT
+#define MERK_LOG printf
+#else
+#define MERK_LOG(...)
+#endif
+
+_Static_assert(sizeof(merkle_node_t) == 64, "merkle_node_t is not 64 bytes!");
+
+#define MERK_NODES_PER_PAGE (RISCV_PAGE_SIZE / sizeof(merkle_node_t))
+
+typedef struct merkle_page_freelist {
+  uint64_t free[MERK_NODES_PER_PAGE / 64];
+  uint16_t free_count;
+  bool in_freelist;
+  struct merkle_page_freelist* next;
+} merkle_page_freelist_t;
+
+_Static_assert(
+    sizeof(merkle_page_freelist_t) <= sizeof(merkle_node_t),
+    "merkle_page_freelist_t does not fit in one merkle_node_t!");
+
+static merkle_page_freelist_t*
+merk_alloc_page(void) {
+  void* page                        = (void*)paging_alloc_backing_page();
+  merkle_page_freelist_t* free_list = (merkle_page_freelist_t*)page;
+  memset(free_list, 0, sizeof(*free_list));
+
+  for (size_t i = 0; i < MERK_NODES_PER_PAGE; i += 64) {
+    size_t this_page_nodes = MERK_NODES_PER_PAGE - i;
+    free_list->free[i / 64] =
+        (this_page_nodes < 64) * (1ull << this_page_nodes) - 1;
+  }
+  free_list->free[0] &= ~(uint64_t)1;
+  free_list->free_count = MERK_NODES_PER_PAGE - 1;
+
+  return free_list;
+}
+
+static merkle_page_freelist_t* merk_free_list = NULL;
+
+static merkle_node_t*
+merk_reserve_node_in_page(merkle_page_freelist_t* free_list) {
+  if (!free_list->free_count) return NULL;
+
+  for (size_t i = 0; i < MERK_NODES_PER_PAGE / 64; i++) {
+    if (free_list->free[i]) {
+      size_t free_idx = __builtin_ctzll(free_list->free[i]);
+      free_list->free[i] &= ~(1ull << free_idx);
+      free_list->free_count--;
+
+      merkle_node_t* page = (merkle_node_t*)free_list;
+      assert(free_idx != 0);
+
+      return page + free_idx;
+    }
+  }
+  return NULL;
+}
+
+static merkle_node_t*
+merk_alloc_node(void) {
+  while (merk_free_list && merk_free_list->free_count == 0) {
+    // Clear out the unfree lists
+    merk_free_list->in_freelist = false;
+    merk_free_list              = merk_free_list->next;
+  }
+
+  if (!merk_free_list) {
+    merk_free_list              = merk_alloc_page();
+    merk_free_list->in_freelist = true;
+  }
+
+  merkle_node_t* out = merk_reserve_node_in_page(merk_free_list);
+  return out;
+}
+
+static void
+merk_free_node(merkle_node_t* node) {
+  uintptr_t page                    = (uintptr_t)node & ~(RISCV_PAGE_SIZE - 1);
+  merkle_page_freelist_t* free_list = (merkle_page_freelist_t*)page;
+  size_t idx                        = node - (merkle_node_t*)page;
+
+  assert(idx < MERK_NODES_PER_PAGE);
+  assert((free_list->free[idx / 64] & (1ull << (idx % 64))) == 0);
+
+  free_list->free[idx / 64] |= (1ull << (idx % 64));
+  free_list->free_count++;
+
+  if (!free_list->in_freelist) {
+    free_list->next        = merk_free_list;
+    merk_free_list         = free_list;
+    free_list->in_freelist = true;
+  }
+}
+
+static bool
+merk_verify_single_node(
+    const merkle_node_t* node, const merkle_node_t* left,
+    const merkle_node_t* right) {
+  SHA256_CTX hasher;
+  uint8_t calculated_hash[32];
+
+  sha256_init(&hasher);
+
+  if (left) {
+    sha256_update(&hasher, left->hash, 32);
+  }
+  if (right) {
+    sha256_update(&hasher, right->hash, 32);
+  }
+
+  if (!left && !right) {
+    return true;
+  }
+
+  sha256_final(&hasher, calculated_hash);
+  return memcmp(calculated_hash, node->hash, 32) == 0;
+}
+
+bool
+merk_verify(
+    volatile merkle_node_t* root, uintptr_t key, const uint8_t hash[32]) {
+  merkle_node_t node = *root;
+  if (!root->right) return false;
+
+  merkle_node_t left;
+  merkle_node_t right = *root->right;
+
+  // Verify root node
+  if (!merk_verify_single_node(&node, NULL, &right)) {
+    MERK_LOG("Error verifying root!\n");
+    return false;
+  }
+
+  node = right;
+
+  for (int i = 0;; i++) {
+    // node is a leaf, so return its hash check
+    if (!node.left && !node.right) {
+      return memcmp(hash, node.hash, 32) == 0;
+    }
+
+    // Load in the next layer. This is to prevent race conditions
+    if (node.left) left = *(volatile merkle_node_t*)node.left;
+    if (node.right) right = *(volatile merkle_node_t*)node.right;
+
+    bool node_ok = merk_verify_single_node(
+        &node, node.left ? &left : NULL, node.right ? &right : NULL);
+    if (!node_ok) {
+      MERK_LOG("Error at node with ptr %zx in layer %d\n", node.ptr, i);
+      return false;
+    }
+
+    // BST traversal
+    if (key < node.ptr) {
+      node = left;
+    } else {
+      node = right;
+    }
+  }
+}
+
+#define MERK_MAX_DEPTH 32
+static merkle_node_t** intermediate_nodes[MERK_MAX_DEPTH] = {};
+
+void
+merk_insert(merkle_node_t* root, uintptr_t key, const uint8_t hash[32]) {
+  SHA256_CTX hasher;
+
+  merkle_node_t* node = merk_alloc_node();
+  *node               = (merkle_node_t){
+      .ptr = key,
+  };
+
+  uint8_t lowest_hash[32];
+
+  memcpy(lowest_hash, hash, 32);
+  memcpy(node->hash, lowest_hash, 32);
+
+  // The root never contains data, only a single pointer to the start
+  // of data on its right side.
+  // This is to better ensure a total split between the root and other
+  // nodes, as the root is merely a "guardian" which must reside in secure
+  // memory while others don't need to.
+  if (!root->right) {
+    root->right = node;
+    return;
+  }
+
+  intermediate_nodes[0] = &root;
+  int i;
+
+  for (i = 1; i < MERK_MAX_DEPTH; i++) {
+    // Walk down the BST to find an appropriate location to store our new node.
+    // Races here don't matter so much as they will corrupt the tree, and the
+    // user will be alerted when attempting to locate a node.
+
+    merkle_node_t* parent = *intermediate_nodes[i - 1];
+
+    if (!parent->left && !parent->right) {
+      merkle_node_t* sibling = parent;
+
+      // We've traversed down to a child node, so break it off into a leaf and
+      // insert a new parent node in its place.
+
+      if (node->ptr < sibling->ptr) {
+        *intermediate_nodes[i - 1] = parent = merk_alloc_node();
+
+        *parent = (merkle_node_t){
+            .ptr   = sibling->ptr,
+            .left  = node,
+            .right = sibling,
+        };
+      } else if (node->ptr > sibling->ptr) {
+        *intermediate_nodes[i - 1] = parent = merk_alloc_node();
+
+        *parent = (merkle_node_t){
+            .ptr   = node->ptr,
+            .left  = sibling,
+            .right = node,
+        };
+      } else {
+        // We've specified a key that already exists, so overwrite the old node.
+        i--;
+        *intermediate_nodes[i] = node;
+        merk_free_node(sibling);
+      }
+      break;
+    }
+
+    // Traverse the BST
+
+    if (node->ptr < parent->ptr) {
+      if (!parent->left) {
+        parent->left = node;
+        break;
+      } else {
+        intermediate_nodes[i] = &parent->left;
+      }
+    } else {
+      if (!parent->right) {
+        parent->right = node;
+        break;
+      } else {
+        intermediate_nodes[i] = &parent->right;
+      }
+    }
+  }
+
+  if (i == MERK_MAX_DEPTH) {
+    printf(
+        "Inserted to merkle tree with problematic key insertion order! "
+        "This has led to an unbalanced tree exceeding the depth capacity of "
+        "%d. "
+        "Aborting!",
+        MERK_MAX_DEPTH);
+    assert(false);
+  }
+
+  for (i = i - 1; i >= 0; i--) {
+    // Here we walk back up the tree to percolate up our new hashes.
+    // We keep the previous iteration's hash, as well as the current iteration's
+    // merkle node, in secure memory to avoid any race conditions after writing
+    // to DRAM in the last step.
+    //
+    // We otherwise aren't concerned that an attacker will modify any data
+    // in the tree during this stage, as doing so will compromise the integrity
+    // of the tree such that the user will be alerted upon attempting any
+    // accesses to the compromised location.
+    //
+    // We also mark accesses to parent_ptr as volatile to ensure they get
+    // written and read with the correct access pattern.
+
+    sha256_init(&hasher);
+    merkle_node_t* parent_ptr = *intermediate_nodes[i];
+    merkle_node_t parent      = *(volatile merkle_node_t*)parent_ptr;
+    assert(!memcmp(
+        lowest_hash, node->hash,
+        32));  // TODO: this sanity checking can probably go away
+
+    // Check which child we are, and compute the parent's hash with our
+    // pre-stored `lowest_hash` and the hash of our sibling, if it exists.
+    if (node == parent.left) {
+      sha256_update(&hasher, lowest_hash, 32);
+      if (parent.right) sha256_update(&hasher, parent.right->hash, 32);
+    } else {
+      assert(node == parent.right);
+      if (parent.left) sha256_update(&hasher, parent.left->hash, 32);
+      sha256_update(&hasher, lowest_hash, 32);
+    }
+
+    sha256_final(&hasher, lowest_hash);
+    memcpy(parent.hash, lowest_hash, 32);
+
+    // Writeback
+    *(volatile merkle_node_t*)parent_ptr = parent;
+    node                                 = parent_ptr;
+  }
+}
+
+#endif

--- a/merkle.h
+++ b/merkle.h
@@ -10,14 +10,19 @@ typedef union merkle_node {
   struct {
     uintptr_t ptr;
     uint8_t hash[32];
-    union merkle_node *left, *right;
+    union {
+      struct {
+        union merkle_node *left, *right;
+      };
+      union merkle_node* children[2];
+    };
   };
   struct {
     uint64_t raw_words[8];
   };
 } merkle_node_t;
 
-void
+int
 merk_insert(merkle_node_t* root, uintptr_t key, const uint8_t hash[32]);
 bool
 merk_verify(

--- a/merkle.h
+++ b/merkle.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#if defined(USE_FREEMEM) && defined(USE_PAGING)
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef union merkle_node {
+  struct {
+    uintptr_t ptr;
+    uint8_t hash[32];
+    union merkle_node *left, *right;
+  };
+  struct {
+    uint64_t raw_words[8];
+  };
+} merkle_node_t;
+
+void
+merk_insert(merkle_node_t* root, uintptr_t key, const uint8_t hash[32]);
+bool
+merk_verify(
+    volatile merkle_node_t* root, uintptr_t key, const uint8_t hash_out[32]);
+
+#endif

--- a/page_swap.c
+++ b/page_swap.c
@@ -1,0 +1,218 @@
+#include "page_swap.h"
+
+#if defined(USE_FREEMEM) && defined(USE_PAGING)
+
+#include <stdatomic.h>
+#include <stddef.h>
+
+#include "aes.h"
+#include "merkle.h"
+#include "paging.h"
+#include "sbi.h"
+#include "sha256.h"
+#include "vm_defs.h"
+
+#define NUM_CTR_INDIRECTS 24
+static uintptr_t ctr_indirect_ptrs[NUM_CTR_INDIRECTS];
+
+static uintptr_t paging_next_backing_page_offset;
+static uintptr_t paging_inc_backing_page_offset_by;
+
+uintptr_t
+paging_alloc_backing_page() {
+  uintptr_t offs_update =
+      (paging_next_backing_page_offset + paging_inc_backing_page_offset_by) %
+      paging_backing_region_size();
+
+  /* no backing page available */
+  if (offs_update == 0) {
+    // cycled through all the pages
+    warn("no backing page avaiable");
+    return 0;
+  }
+
+  uintptr_t next_page =
+      paging_backing_region() + paging_next_backing_page_offset;
+  assert(IS_ALIGNED(next_page, RISCV_PAGE_BITS));
+
+  paging_next_backing_page_offset = offs_update;
+  return next_page;
+}
+
+unsigned int
+paging_remaining_pages() {
+  return (paging_backing_region_size() - paging_next_backing_page_offset) /
+         RISCV_PAGE_SIZE;
+}
+
+static uintptr_t
+gcd(uintptr_t a, uintptr_t b) {
+  while (b) {
+    uintptr_t tmp = b;
+    b             = a % b;
+    a             = tmp;
+  }
+  return a;
+}
+
+static uintptr_t
+find_coprime_of(uintptr_t n) {
+  uintptr_t res;
+  do {
+    res = n / 2 + sbi_random() % (n / 2);
+  } while (gcd(res, n) != 1);
+  return res;
+}
+
+void
+pswap_init(void) {
+  uintptr_t backing_pages = paging_backing_region_size() / RISCV_PAGE_SIZE;
+  uintptr_t inc           = find_coprime_of(backing_pages);
+
+  paging_inc_backing_page_offset_by = inc * RISCV_PAGE_SIZE;
+  warn("num_pages = %zx, pagesize_inc = %zx", backing_pages, inc);
+
+  paging_next_backing_page_offset = 0;
+}
+
+static uint64_t*
+pswap_pageout_ctr(uintptr_t page) {
+  assert(paging_backpage_inbounds(page));
+  size_t idx          = (page - paging_backing_region()) >> RISCV_PAGE_BITS;
+  size_t indirect_idx = idx / (RISCV_PAGE_SIZE / 8);
+  size_t interior_idx = idx % (RISCV_PAGE_SIZE / 8);
+  assert(indirect_idx < NUM_CTR_INDIRECTS);
+
+  if (!ctr_indirect_ptrs[indirect_idx]) {
+    ctr_indirect_ptrs[indirect_idx] = paging_alloc_backing_page();
+    // Fill ptr pages with random values so our counters start unpredictable
+    rt_util_getrandom((void*)ctr_indirect_ptrs[indirect_idx], RISCV_PAGE_SIZE);
+  }
+
+  return (uint64_t*)(ctr_indirect_ptrs[indirect_idx]) + interior_idx;
+}
+
+#ifdef USE_PAGE_CRYPTO
+static volatile atomic_bool pswap_boot_key_reserved = false;
+static volatile atomic_bool pswap_boot_key_set      = false;
+static uint8_t pswap_boot_key[32];
+
+static void
+pswap_establish_boot_key(void) {
+  uint8_t boot_key_tmp[32];
+
+  if (atomic_load(&pswap_boot_key_set)) {
+    // Key already set
+    return;
+  }
+
+  rt_util_getrandom(boot_key_tmp, 32);
+
+  if (atomic_flag_test_and_set(&pswap_boot_key_reserved)) {
+    // Lost the race; key already being set. Spin until finished.
+    while (!atomic_load(&pswap_boot_key_set))
+      ;
+    return;
+  }
+
+  memcpy(pswap_boot_key, boot_key_tmp, 32);
+  atomic_store(&pswap_boot_key_set, true);
+}
+#endif  // USE_PAGE_CRYPTO
+
+#ifdef USE_PAGE_HASH
+static merkle_node_t paging_merk_root = {};
+#endif
+
+static void
+pswap_encrypt(const void* addr, void* dst, uint64_t pageout_ctr) {
+  size_t len = RISCV_PAGE_SIZE;
+
+#ifdef USE_PAGE_CRYPTO
+  pswap_establish_boot_key();
+  uint8_t iv[32] = {0};
+  WORD key_sched[80];
+  aes_key_setup(pswap_boot_key, key_sched, 256);
+
+  memcpy(iv + 8, &pageout_ctr, 8);
+
+  aes_encrypt_ctr((uint8_t*)addr, len, (uint8_t*)dst, key_sched, 256, iv);
+#else
+  memcpy(dst, addr, len);
+#endif
+}
+
+static void
+pswap_decrypt(const void* addr, void* dst, uint64_t pageout_ctr) {
+  size_t len = RISCV_PAGE_SIZE;
+
+#ifdef USE_PAGE_CRYPTO
+  pswap_establish_boot_key();
+  uint8_t iv[32] = {0};
+  WORD key_sched[80];
+  aes_key_setup(pswap_boot_key, key_sched, 256);
+
+  memcpy(iv + 8, &pageout_ctr, 8);
+
+  aes_decrypt_ctr((uint8_t*)addr, len, (uint8_t*)dst, key_sched, 256, iv);
+#else
+  memcpy(dst, addr, len);
+#endif
+}
+
+static void
+pswap_hash(uint8_t* hash, void* page_addr, uint64_t pageout_ctr) {
+#ifdef USE_PAGE_HASH
+  SHA256_CTX hasher;
+
+  sha256_init(&hasher);
+  sha256_update(&hasher, page_addr, RISCV_PAGE_SIZE);
+  sha256_update(&hasher, (uint8_t*)&pageout_ctr, sizeof(pageout_ctr));
+  sha256_final(&hasher, hash);
+#endif
+}
+
+/* evict a page from EPM and store it to the backing storage
+ * back_page (PA1) <-- epm_page (PA2) <-- swap_page (PA1)
+ * if swap_page is 0, no need to write epm_page
+ */
+void
+page_swap_epm(uintptr_t back_page, uintptr_t epm_page, uintptr_t swap_page) {
+  assert(paging_epm_inbounds(epm_page));
+  assert(paging_backpage_inbounds(back_page));
+
+  char buffer[RISCV_PAGE_SIZE] = {};
+  if (swap_page) {
+    assert(swap_page == back_page);
+    memcpy(buffer, (void*)swap_page, RISCV_PAGE_SIZE);
+  }
+
+  uint64_t* pageout_ctr    = pswap_pageout_ctr(back_page);
+  uint64_t old_pageout_ctr = *pageout_ctr;
+  uint64_t new_pageout_ctr = old_pageout_ctr + 1;
+
+  uint8_t new_hash[32];
+  pswap_hash(new_hash, (void*)epm_page, new_pageout_ctr);
+  pswap_encrypt((void*)epm_page, (void*)back_page, new_pageout_ctr);
+
+  if (swap_page) {
+    uint8_t old_hash[32];
+    pswap_decrypt((void*)buffer, (void*)epm_page, old_pageout_ctr);
+    pswap_hash(old_hash, (void*)epm_page, old_pageout_ctr);
+
+#ifdef USE_PAGE_HASH
+    bool ok = merk_verify(&paging_merk_root, back_page, old_hash);
+    assert(ok);
+#endif
+  }
+
+#ifdef USE_PAGE_HASH
+  merk_insert(&paging_merk_root, back_page, new_hash);
+#endif
+
+  *pageout_ctr = new_pageout_ctr;
+
+  return;
+}
+
+#endif

--- a/page_swap.h
+++ b/page_swap.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdint.h>
+
+void
+pswap_init(void);
+
+void
+page_swap_epm(uintptr_t back_page, uintptr_t epm_page, uintptr_t swap_page);

--- a/paging.c
+++ b/paging.c
@@ -27,8 +27,8 @@ void paging_dec_user_page(void)
   assert(paging_user_page_count >= 0);
 }
 
-uintptr_t __alloc_backing_page()
-{
+uintptr_t
+paging_alloc_backing_page() {
   uintptr_t next_page;
 
   /* no backing page available */
@@ -241,7 +241,7 @@ uintptr_t paging_evict_and_free_one(uintptr_t swap_va)
   if(swap_va)
     dest_va = swap_va;
   else
-    dest_va = __alloc_backing_page();
+    dest_va = paging_alloc_backing_page();
 
   assert(dest_va >= paging_backing_storage_addr);
   assert(dest_va < paging_backing_storage_addr +

--- a/paging.c
+++ b/paging.c
@@ -6,13 +6,22 @@
 
 #include "paging.h"
 
+#include <stdatomic.h>
+
+#include "aes.h"
+#include "merkle.h"
+#include "sha256.h"
 #include "vm.h"
 
 uintptr_t paging_backing_storage_addr;
 uintptr_t paging_backing_storage_size;
 uintptr_t paging_next_backing_page_offset;
+uintptr_t paging_inc_backing_page_offset_by;
 
 static uintptr_t paging_user_page_count = 0;
+
+#define NUM_CTR_INDIRECTS 24
+static uintptr_t ctr_indirect_ptrs[NUM_CTR_INDIRECTS];
 
 extern uintptr_t rt_trap_table;
 
@@ -29,19 +38,22 @@ void paging_dec_user_page(void)
 
 uintptr_t
 paging_alloc_backing_page() {
-  uintptr_t next_page;
+  uintptr_t offs_update =
+      (paging_next_backing_page_offset + paging_inc_backing_page_offset_by) %
+      paging_backing_storage_size;
 
   /* no backing page available */
-  if (paging_next_backing_page_offset >= paging_backing_storage_size) {
+  if (offs_update == 0) {
+    // cycled through all the pages
     warn("no backing page avaiable");
     return 0;
   }
 
-  next_page = paging_backing_storage_addr + paging_next_backing_page_offset;
+  uintptr_t next_page =
+      paging_backing_storage_addr + paging_next_backing_page_offset;
   assert(IS_ALIGNED(next_page, RISCV_PAGE_BITS));
 
-  paging_next_backing_page_offset += RISCV_PAGE_SIZE;
-
+  paging_next_backing_page_offset = offs_update;
   return next_page;
 }
 
@@ -49,6 +61,25 @@ unsigned int
 paging_remaining_pages()
 {
   return (paging_backing_storage_size - paging_next_backing_page_offset)/RISCV_PAGE_SIZE;
+}
+
+uintptr_t
+gcd(uintptr_t a, uintptr_t b) {
+  while (b) {
+    uintptr_t tmp = b;
+    b             = a % b;
+    a             = tmp;
+  }
+  return a;
+}
+
+uintptr_t
+find_coprime_of(uintptr_t n) {
+  uintptr_t res;
+  do {
+    res = n / 2 + sbi_random() % (n / 2);
+  } while (gcd(res, n) != 1);
+  return res;
 }
 
 void init_paging(uintptr_t user_pa_start, uintptr_t user_pa_end)
@@ -76,6 +107,13 @@ void init_paging(uintptr_t user_pa_start, uintptr_t user_pa_end)
   paging_pa_start = addr;
   paging_backing_storage_size = size;
   paging_backing_storage_addr = __paging_va(addr);
+
+  uintptr_t backing_pages = paging_backing_storage_size / RISCV_PAGE_SIZE;
+  uintptr_t inc           = find_coprime_of(backing_pages);
+
+  paging_inc_backing_page_offset_by = inc * RISCV_PAGE_SIZE;
+  warn("num_pages = %zx, pagesize_inc = %zx", backing_pages, inc);
+
   paging_next_backing_page_offset = 0;
 
   debug("BACK: 0x%lx-0x%lx (%u KB), va 0x%lx", addr, addr + size, size/1024, paging_backing_storage_addr);
@@ -190,6 +228,103 @@ uintptr_t __pick_page()
   return target;
 }
 
+#ifdef USE_PAGE_CRYPTO
+static volatile atomic_bool paging_boot_key_reserved = false;
+static volatile atomic_bool paging_boot_key_set      = false;
+static uint8_t paging_boot_key[32];
+
+static void
+establish_boot_key(void) {
+  uint8_t boot_key_tmp[32];
+
+  if (atomic_load(&paging_boot_key_set)) {
+    // Key already set
+    return;
+  }
+
+  rt_util_getrandom(boot_key_tmp, 32);
+
+  if (atomic_flag_test_and_set(&paging_boot_key_reserved)) {
+    // Lost the race; key already being set. Spin until finished.
+    while (!atomic_load(&paging_boot_key_set))
+      ;
+    return;
+  }
+
+  memcpy(paging_boot_key, boot_key_tmp, 32);
+  atomic_store(&paging_boot_key_set, true);
+}
+#endif  // USE_PAGE_CRYPTO
+
+static uint64_t*
+pageout_ctr_ptr(uintptr_t page) {
+  assert(page >= paging_backing_storage_addr);
+  size_t idx          = (page - paging_backing_storage_addr) >> RISCV_PAGE_BITS;
+  size_t indirect_idx = idx / (RISCV_PAGE_SIZE / 8);
+  size_t interior_idx = idx % (RISCV_PAGE_SIZE / 8);
+  assert(indirect_idx < NUM_CTR_INDIRECTS);
+
+  if (!ctr_indirect_ptrs[indirect_idx]) {
+    ctr_indirect_ptrs[indirect_idx] = paging_alloc_backing_page();
+    // Fill ptr pages with random values so our counters start unpredictable
+    rt_util_getrandom((void*)ctr_indirect_ptrs[indirect_idx], RISCV_PAGE_SIZE);
+  }
+
+  return (uint64_t*)(ctr_indirect_ptrs[indirect_idx]) + interior_idx;
+}
+
+#ifdef USE_PAGE_HASH
+static merkle_node_t paging_merk_root = {};
+#endif
+
+static void
+encrypt_page(const void* addr, void* dst, uint64_t pageout_ctr) {
+  size_t len = RISCV_PAGE_SIZE;
+
+#ifdef USE_PAGE_CRYPTO
+  establish_boot_key();
+  uint8_t iv[32] = {0};
+  WORD key_sched[80];
+  aes_key_setup(paging_boot_key, key_sched, 256);
+
+  memcpy(iv + 8, &pageout_ctr, 8);
+
+  aes_encrypt_ctr((uint8_t*)addr, len, (uint8_t*)dst, key_sched, 256, iv);
+#else
+  memcpy(dst, addr, len);
+#endif
+}
+
+static void
+decrypt_page(const void* addr, void* dst, uint64_t pageout_ctr) {
+  size_t len = RISCV_PAGE_SIZE;
+
+#ifdef USE_PAGE_CRYPTO
+  establish_boot_key();
+  uint8_t iv[32] = {0};
+  WORD key_sched[80];
+  aes_key_setup(paging_boot_key, key_sched, 256);
+
+  memcpy(iv + 8, &pageout_ctr, 8);
+
+  aes_decrypt_ctr((uint8_t*)addr, len, (uint8_t*)dst, key_sched, 256, iv);
+#else
+  memcpy(dst, addr, len);
+#endif
+}
+
+static void
+hash_page(uint8_t* hash, void* page_addr, uint64_t pageout_ctr) {
+#ifdef USE_PAGE_HASH
+  SHA256_CTX hasher;
+
+  sha256_init(&hasher);
+  sha256_update(&hasher, page_addr, RISCV_PAGE_SIZE);
+  sha256_update(&hasher, (uint8_t*)&pageout_ctr, sizeof(pageout_ctr));
+  sha256_final(&hasher, hash);
+#endif
+}
+
 /* evict a page from EPM and store it to the backing storage
  * back_page (PA1) <-- epm_page (PA2) <-- swap_page (PA1)
  * if swap_page is 0, no need to write epm_page
@@ -201,20 +336,36 @@ void __swap_epm_page(uintptr_t back_page, uintptr_t epm_page, uintptr_t swap_pag
   assert(back_page >= paging_backing_storage_addr);
   assert(back_page < paging_backing_storage_addr + paging_backing_storage_size);
 
-  /* not implemented */
-  assert(!encrypt);
-
   char buffer[RISCV_PAGE_SIZE] = {0,};
   if (swap_page) {
     assert(swap_page == back_page);
     memcpy(buffer, (void*)swap_page, RISCV_PAGE_SIZE);
   }
 
-  memcpy((void*)back_page, (void*)epm_page, RISCV_PAGE_SIZE);
+  uint64_t* pageout_ctr    = pageout_ctr_ptr(back_page);
+  uint64_t old_pageout_ctr = *pageout_ctr;
+  uint64_t new_pageout_ctr = old_pageout_ctr + 1;
+
+  uint8_t new_hash[32];
+  hash_page(new_hash, (void*)epm_page, new_pageout_ctr);
+  encrypt_page((void*)epm_page, (void*)back_page, new_pageout_ctr);
 
   if (swap_page) {
-    memcpy((void*)epm_page, buffer, RISCV_PAGE_SIZE);
+    uint8_t old_hash[32];
+    decrypt_page((void*)buffer, (void*)epm_page, old_pageout_ctr);
+    hash_page(old_hash, (void*)epm_page, old_pageout_ctr);
+
+#ifdef USE_PAGE_HASH
+    bool ok = merk_verify(&paging_merk_root, back_page, old_hash);
+    assert(ok);
+#endif
   }
+
+#ifdef USE_PAGE_HASH
+  merk_insert(&paging_merk_root, back_page, new_hash);
+#endif
+
+  *pageout_ctr = new_pageout_ctr;
 
   return;
 }
@@ -252,7 +403,7 @@ uintptr_t paging_evict_and_free_one(uintptr_t swap_va)
   assert(target_pte && (*target_pte & PTE_U));
 
   src_pa = pte_ppn(*target_pte) << RISCV_PAGE_BITS;
-  __swap_epm_page(dest_va, __va(src_pa), swap_va, false);
+  __swap_epm_page(dest_va, __va(src_pa), swap_va, true);
 
   /* invalidate target PTE */
   *target_pte = pte_create_invalid(ppn(__paging_pa(dest_va)),

--- a/paging.h
+++ b/paging.h
@@ -35,5 +35,8 @@ static inline uintptr_t __paging_va(uintptr_t pa)
   return (pa - paging_pa_start) + EYRIE_PAGING_START;
 }
 
+uintptr_t
+paging_alloc_backing_page(void);
+
 #endif
 #endif

--- a/paging.h
+++ b/paging.h
@@ -18,10 +18,13 @@ unsigned int paging_remaining_pages(void);
 void init_paging(uintptr_t user_pa_start, uintptr_t user_pa_end);
 void paging_handle_page_fault(struct encl_ctx* ctx);
 uintptr_t paging_evict_and_free_one(uintptr_t swap_va);
-uintptr_t paging_pa_start;
 
-pte paging_l2_page_table[BIT(RISCV_PT_INDEX_BITS)] __attribute__((aligned(RISCV_PAGE_SIZE)));
-pte paging_l3_page_table[BIT(RISCV_PT_INDEX_BITS)] __attribute__((aligned(RISCV_PAGE_SIZE)));
+extern uintptr_t paging_pa_start;
+extern pte paging_l2_page_table[BIT(RISCV_PT_INDEX_BITS)]
+    __attribute__((aligned(RISCV_PAGE_SIZE)));
+extern pte paging_l3_page_table[BIT(RISCV_PT_INDEX_BITS)]
+    __attribute__((aligned(RISCV_PAGE_SIZE)));
+
 void paging_inc_user_page(void);
 void paging_dec_user_page(void);
 /* page tables for loading physical memory */
@@ -37,6 +40,15 @@ static inline uintptr_t __paging_va(uintptr_t pa)
 
 uintptr_t
 paging_alloc_backing_page(void);
+
+uintptr_t
+paging_backing_region(void);
+uintptr_t
+paging_backing_region_size(void);
+bool
+paging_epm_inbounds(uintptr_t addr);
+bool
+paging_backpage_inbounds(uintptr_t addr);
 
 #endif
 #endif

--- a/printf.h
+++ b/printf.h
@@ -34,7 +34,6 @@
 
 #include <stdarg.h>
 #include <stddef.h>
-#include "sbi.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,4 +13,8 @@ add_cmocka_test(test_merkle
     SOURCES merkle.c ../sha256.c
     COMPILE_OPTIONS -DUSE_PAGE_HASH -DUSE_PAGING -DUSE_FREEMEM -D__riscv_xlen=64 -I${CMAKE_BINARY_DIR}/cmocka/include -g
     LINK_LIBRARIES cmocka)
+add_cmocka_test(test_pageswap
+    SOURCES page_swap.c ../merkle.c ../sha256.c ../aes.c
+    COMPILE_OPTIONS -DUSE_PAGE_HASH -DUSE_PAGE_CRYPTO -DUSE_PAGING -DUSE_FREEMEM -D__riscv_xlen=64 -I${CMAKE_BINARY_DIR}/cmocka/include -g
+    LINK_LIBRARIES cmocka)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,3 +9,8 @@ include(AddCMockaTest)
 enable_testing()
 
 add_cmocka_test(test_string SOURCES string.c COMPILE_OPTIONS -I${CMAKE_BINARY_DIR}/cmocka/include LINK_LIBRARIES cmocka)
+add_cmocka_test(test_merkle
+    SOURCES merkle.c ../sha256.c
+    COMPILE_OPTIONS -DUSE_PAGE_HASH -DUSE_PAGING -DUSE_FREEMEM -D__riscv_xlen=64 -I${CMAKE_BINARY_DIR}/cmocka/include -g
+    LINK_LIBRARIES cmocka)
+

--- a/test/merkle.c
+++ b/test/merkle.c
@@ -1,7 +1,5 @@
 #define _GNU_SOURCE
 
-#define SBI_CALL(...) 0
-
 #include "../merkle.h"
 
 #include <math.h>
@@ -15,6 +13,11 @@
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+void
+sbi_exit_enclave(uintptr_t code) {
+  exit(code);
+}
 
 uintptr_t
 paging_alloc_backing_page() {

--- a/test/merkle.c
+++ b/test/merkle.c
@@ -1,0 +1,331 @@
+#define _GNU_SOURCE
+
+#define SBI_CALL(...) 0
+
+#include "../merkle.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/mman.h>
+
+#define MERK_SILENT
+#include "../merkle.c"
+#include "mock.h"
+
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+uintptr_t
+paging_alloc_backing_page() {
+  void* out = mmap(
+      NULL, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert_int_not_equal(out, MAP_FAILED);
+  return (uintptr_t)out;
+}
+
+#define RAND_REGION_ENTRIES 1000
+#define RAND_ENTRY_SIZE 64
+
+const uint8_t*
+random_region() {
+  static const uint8_t* random_region_buf = NULL;
+  if (!random_region_buf)
+    random_region_buf = (uint8_t*)malloc(RAND_REGION_ENTRIES * RAND_ENTRY_SIZE);
+  return random_region_buf;
+}
+
+size_t*
+shuffled_idxs(size_t max) {
+  size_t* shuffled_idxs = (size_t*)malloc(sizeof(size_t) * max);
+  for (size_t i = 0; i < max; i++) shuffled_idxs[i] = i;
+
+  for (size_t i = max - 1; i > 0; i--) {
+    size_t j         = rand() % i + 1;
+    size_t tmp       = shuffled_idxs[i];
+    shuffled_idxs[i] = shuffled_idxs[j];
+    shuffled_idxs[j] = tmp;
+  }
+  return shuffled_idxs;
+}
+
+static merkle_node_t
+random_region_insert(merkle_node_t* root) {
+  const uint8_t* region = random_region();
+  size_t* idxs          = shuffled_idxs(RAND_REGION_ENTRIES);
+
+  SHA256_CTX sha;
+
+  for (int i = 0; i < RAND_REGION_ENTRIES; i++) {
+    const uint8_t* subregion = region + idxs[i] * RAND_ENTRY_SIZE;
+    uint8_t hash[32];
+
+    sha256_init(&sha);
+    sha256_update(&sha, subregion, RAND_ENTRY_SIZE);
+    sha256_final(&sha, hash);
+
+    merk_insert(root, (uintptr_t)subregion, hash);
+  }
+
+  free(idxs);
+}
+
+static merkle_node_t
+random_region_tree() {
+  merkle_node_t root = {};
+  random_region_insert(&root);
+  return root;
+}
+
+static size_t
+count_verify_fails(merkle_node_t* tree) {
+  size_t total_verify_fails = 0;
+  SHA256_CTX sha;
+
+  size_t* idxs = shuffled_idxs(RAND_REGION_ENTRIES);
+
+  for (size_t ri = 0; ri < RAND_REGION_ENTRIES; ri++) {
+    const uint8_t* region = random_region() + idxs[ri] * RAND_ENTRY_SIZE;
+    uint8_t region_hash[32];
+    sha256_init(&sha);
+    sha256_update(&sha, region, RAND_ENTRY_SIZE);
+    sha256_final(&sha, region_hash);
+    total_verify_fails += !merk_verify(tree, (uintptr_t)region, region_hash);
+  }
+
+  free(idxs);
+  return total_verify_fails;
+}
+
+struct merk_stats_s {
+  size_t max_depth, min_depth;
+  size_t elems, leaves;
+  double avg_depth;
+};
+
+struct merk_stats_s
+merk_stats(const merkle_node_t* root) {
+  const merkle_node_t *left = root->left, *right = root->right;
+
+  struct merk_stats_s out = {
+      .max_depth = 1,
+      .min_depth = 1,
+      .elems     = 1,
+      .leaves    = 0,
+      .avg_depth = 1,
+  };
+
+  if (!left && !right) {
+    out.leaves = 1;
+    return out;
+  }
+
+  struct merk_stats_s lstats, rstats;
+  if (left) {
+    lstats        = merk_stats(left);
+    out.max_depth = lstats.max_depth;
+    out.min_depth = lstats.min_depth;
+    out.elems += lstats.elems;
+    out.leaves += lstats.leaves;
+    out.avg_depth = lstats.avg_depth + 1;
+  }
+  if (right) {
+    rstats        = merk_stats(right);
+    out.max_depth = rstats.max_depth;
+    out.min_depth = rstats.min_depth;
+    out.elems += rstats.elems;
+    out.leaves += rstats.leaves;
+    out.avg_depth = rstats.avg_depth + 1;
+  }
+  if (left && right) {
+    double both_elems = lstats.elems + rstats.elems;
+    double lweight    = lstats.elems / both_elems;
+    double rweight    = rstats.elems / both_elems;
+    out.max_depth     = MAX(lstats.max_depth, rstats.max_depth) + 1;
+    out.min_depth     = MIN(lstats.max_depth, rstats.max_depth) + 1;
+    out.avg_depth = lweight * lstats.avg_depth + rweight * rstats.avg_depth + 1;
+  }
+  return out;
+}
+
+static void
+test_verify_nonexistant() {
+  merkle_node_t root = {};
+  uint8_t zeros[32]  = {};
+  assert_false(merk_verify(&root, 1, zeros));
+}
+
+static void
+test_insert_and_verify() {
+  merkle_node_t root = random_region_tree();
+  assert_int_equal(count_verify_fails(&root), 0);
+  struct merk_stats_s stats_0 = merk_stats(&root);
+
+  random_region_insert(&root);
+  assert_int_equal(count_verify_fails(&root), 0);
+  struct merk_stats_s stats_1 = merk_stats(&root);
+
+  assert_memory_equal(&stats_0, &stats_1, sizeof(struct merk_stats_s));
+}
+
+static void
+test_random_insert_stats() {
+  merkle_node_t root        = random_region_tree();
+  struct merk_stats_s stats = merk_stats(&root);
+  assert_int_equal(stats.leaves, RAND_REGION_ENTRIES);
+  assert_in_range(stats.elems, stats.leaves, stats.leaves * 2);
+  assert_true(stats.min_depth > log2(RAND_REGION_ENTRIES));
+  assert_true(stats.max_depth < 4 * log2(RAND_REGION_ENTRIES));
+  assert_true(stats.avg_depth < 2 * log2(RAND_REGION_ENTRIES));
+}
+
+static void
+test_poison_data() {
+  merkle_node_t root        = random_region_tree();
+  size_t poison_idx         = rand() % RAND_REGION_ENTRIES;
+  const uint8_t* poison_ptr = random_region() + poison_idx * RAND_ENTRY_SIZE;
+
+  SHA256_CTX sha;
+  uint8_t hash[32];
+  sha256_init(&sha);
+  sha256_update(&sha, poison_ptr, RAND_ENTRY_SIZE);
+  sha256_final(&sha, hash);
+
+  // Flip a random bit in the hash to simulate a tampered entry
+  hash[rand() & 31] ^= 1 << (rand() & 7);
+
+  bool res = merk_verify(&root, (uintptr_t)poison_ptr, hash);
+  assert_false(res);
+}
+
+static void
+flip_random_bit(uint8_t* buf, size_t size) {
+  buf[rand() % size] ^= 1 << (rand() & 7);
+}
+
+static void
+test_poison_leaf() {
+  merkle_node_t root  = random_region_tree();
+  merkle_node_t* node = &root;
+
+  // Randomly walk the tree until we get to a leaf
+  while (node->left || node->right) {
+    merkle_node_t* next[2];
+    int num_next   = 0;
+    next[num_next] = node->left;
+    num_next += !!node->left;
+    next[num_next] = node->right;
+    num_next += !!node->right;
+
+    int taken = rand() % num_next;
+    node      = next[taken];
+  }
+
+  uintptr_t key = node->ptr;
+  uint8_t* hash = node->hash;
+  // Simulate a tampered entry
+  flip_random_bit(hash, 32);
+
+  bool res = merk_verify(&root, key, hash);
+  assert_false(res);
+}
+
+static void
+test_poison_root() {
+  merkle_node_t root = random_region_tree();
+  flip_random_bit(root.hash, 32);
+
+  size_t total_verify_fails = count_verify_fails(&root);
+  assert_int_equal(total_verify_fails, RAND_REGION_ENTRIES);
+}
+
+static void
+test_insert_corrupt_insert() {
+  merkle_node_t root = random_region_tree();
+
+  // Find a node that has a leaf on the right, and a sibling or nephew on the
+  // left
+  // TODO: not all trees may have this structure
+  merkle_node_t* node = &root;
+  assert_non_null(node->right);
+  assert_non_null(node->right->right);
+
+  while (node->right->right) {
+    node = node->right;
+  }
+
+  merkle_node_t* leaf = node->right;
+  // Find the position of the sibling/nephew leaf
+  merkle_node_t* sibling = node->left;
+
+  assert_non_null(leaf);
+  assert_non_null(sibling);
+
+  while (sibling->left) {
+    sibling = sibling->left;
+  }
+
+  assert_null(leaf->left);
+  assert_null(leaf->right);
+  assert_null(sibling->left);
+  assert_null(sibling->right);
+
+  // Check to make sure both start off okay
+  bool ok = merk_verify(&root, leaf->ptr, leaf->hash);
+  ok &= merk_verify(&root, sibling->ptr, sibling->hash);
+  assert_true(ok);
+
+  // When we corrupt the leaf hash, we expect the leaf check to fail
+  flip_random_bit(leaf->hash, 32);
+
+  merkle_node_t leaf_copy = *leaf, sibling_copy = *sibling;
+  ok = merk_verify(&root, leaf_copy.ptr, leaf_copy.hash);
+  assert_false(ok);
+
+  // Test that merk_insert doesn't incorrectly "validate" a hash that isn't the
+  // one we inserted
+  merk_insert(&root, sibling_copy.ptr, sibling_copy.hash);
+  ok = merk_verify(&root, leaf_copy.ptr, leaf_copy.hash);
+  assert_false(ok);
+}
+
+static void
+test_corrupt_key() {
+  merkle_node_t root = {};
+  SHA256_CTX sha;
+
+  merk_insert(&root, 1, random_region());
+  merk_insert(&root, 2, random_region() + 32);
+
+  assert_true(merk_verify(&root, 1, random_region()));
+  assert_true(merk_verify(&root, 2, random_region() + 32));
+
+  // Swap the keys for entries 1 and 2
+  assert_non_null(root.right);
+  merkle_node_t *first = root.right->left, *second = root.right->right;
+  assert_non_null(first);
+  assert_non_null(second);
+
+  assert_int_equal(first->ptr, 1);
+  first->ptr = 2;
+  assert_int_equal(second->ptr, 2);
+  second->ptr = 1;
+
+  assert_false(merk_verify(&root, 1, random_region()));
+  assert_false(merk_verify(&root, 2, random_region() + 32));
+}
+
+int
+main() {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_verify_nonexistant),
+      cmocka_unit_test(test_insert_and_verify),
+      cmocka_unit_test(test_random_insert_stats),
+      cmocka_unit_test(test_poison_data),
+      cmocka_unit_test(test_poison_leaf),
+      cmocka_unit_test(test_poison_root),
+      cmocka_unit_test(test_insert_corrupt_insert),
+      cmocka_unit_test(test_corrupt_key),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/page_swap.c
+++ b/test/page_swap.c
@@ -1,0 +1,175 @@
+#define _GNU_SOURCE
+
+#include "../page_swap.c"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/mman.h>
+
+#include "mock.h"
+
+void
+sbi_exit_enclave(uintptr_t code) {
+  exit(code);
+}
+
+uintptr_t
+sbi_random() {
+  uintptr_t out;
+  rt_util_getrandom(&out, sizeof out);
+  return out;
+}
+
+size_t
+rt_util_getrandom(void* vaddr, size_t buflen) {
+  uint8_t* charbuf = (uint8_t*)vaddr;
+  for (size_t i = 0; i < buflen; i++) charbuf[i] = rand();
+  return buflen;
+}
+
+bool
+paging_epm_inbounds(uintptr_t addr) {
+  (void)addr;
+  return true;
+}
+
+static void* backing_region;
+#define BACKING_REGION_SIZE (2 * 1024 * 1024)
+
+bool
+paging_backpage_inbounds(uintptr_t addr) {
+  return (addr >= (uintptr_t)backing_region) &&
+         (addr < (uintptr_t)backing_region + BACKING_REGION_SIZE);
+}
+
+uintptr_t
+paging_backing_region() {
+  if (!backing_region) {
+    backing_region = mmap(
+        NULL, BACKING_REGION_SIZE, PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    assert_int_not_equal(backing_region, MAP_FAILED);
+  }
+  return (uintptr_t)backing_region;
+}
+uintptr_t
+paging_backing_region_size() {
+  return BACKING_REGION_SIZE;
+}
+
+static uintptr_t
+palloc() {
+  void* out = mmap(
+      NULL, RISCV_PAGE_SIZE, PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert_int_not_equal(out, MAP_FAILED);
+  return (uintptr_t)out;
+}
+
+static void
+pfree(uintptr_t page) {
+  int res = munmap((void*)page, RISCV_PAGE_SIZE);
+  assert_int_equal(res, 0);
+}
+
+typedef struct {
+  uint8_t dat[32];
+} hash_s;
+static hash_s
+hash_page(uintptr_t page) {
+  hash_s out;
+  SHA256_CTX sha;
+  sha256_init(&sha);
+  sha256_update(&sha, (uint8_t*)page, RISCV_PAGE_SIZE);
+  sha256_final(&sha, out.dat);
+  return out;
+}
+static bool
+hash_eq(hash_s* h1, hash_s* h2) {
+  return !memcmp(h1, h2, sizeof(hash_s));
+}
+
+static double
+bit_similarity(uintptr_t page1, uintptr_t page2) {
+  double avg = 0;
+  size_t n   = 0;
+
+  uint64_t* p1buf = (uint64_t*)page1;
+  uint64_t* p2buf = (uint64_t*)page2;
+  for (size_t i = 0; i < RISCV_PAGE_SIZE / 8; i++) {
+    double word_similarity =
+        (double)__builtin_popcountll(p1buf[i] ^ p2buf[i]) / 64.0;
+    avg += (word_similarity - avg) / ++n;
+  }
+
+  return avg;
+}
+static double
+bit_similarity_sd() {
+  // For 2 IID pages, each bit is similar with probability 0.5.
+  // So the sum of all similarities follows a binomial distribution
+  // B(8*PAGE_SIZE, 0.5). The mean # of similar bits is 4*PAGE_SIZE, +/-
+  // sqrt(2*PAGE_SIZE) So the mean similarity is 0.5 +/- 1/sqrt(8*PAGE_SIZE)
+  // With PAGE_SIZE=4096, this is 0.5 */- 0.0028
+
+  return 1.0 / sqrt(8 * RISCV_PAGE_SIZE);
+}
+
+void
+test_swapout_randomness() {
+  pswap_init();
+
+  uintptr_t back_page  = paging_alloc_backing_page();
+  uintptr_t front_page = palloc();
+  rt_util_getrandom((void*)front_page, RISCV_PAGE_SIZE);
+
+  page_swap_epm(back_page, front_page, 0);
+
+  // Backing page should be essentially random.
+  double sim = bit_similarity(back_page, front_page);
+  assert_true(sim < 0.5 + 4 * bit_similarity_sd());
+  assert_true(sim > 0.5 - 4 * bit_similarity_sd());
+
+  pfree(front_page);
+}
+
+void
+test_swap_out_in() {
+  pswap_init();
+
+  uintptr_t back_page  = paging_alloc_backing_page();
+  uintptr_t front_page = palloc();
+  rt_util_getrandom((void*)front_page, RISCV_PAGE_SIZE);
+
+  hash_s back_hash  = hash_page(back_page);
+  hash_s front_hash = hash_page(front_page);
+
+  page_swap_epm(back_page, front_page, 0);
+
+  hash_s back_swp_hash  = hash_page(back_page);
+  hash_s front_swp_hash = hash_page(front_page);
+  assert_false(hash_eq(&back_hash, &back_swp_hash));
+  assert_true(hash_eq(&front_hash, &front_swp_hash));
+
+  // Randomize front_page and then swap back in our old front_page
+  rt_util_getrandom((void*)front_page, RISCV_PAGE_SIZE);
+  page_swap_epm(back_page, front_page, back_page);
+
+  hash_s back_swp_hash2  = hash_page(back_page);
+  hash_s front_swp_hash2 = hash_page(front_page);
+  assert_false(hash_eq(&back_hash, &back_swp_hash2));
+  assert_false(hash_eq(&back_swp_hash, &back_swp_hash2));
+  assert_true(hash_eq(&front_hash, &front_swp_hash2));
+
+  pfree(front_page);
+}
+
+int
+main() {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_swapout_randomness),
+      cmocka_unit_test(test_swap_out_in),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Aside from the obvious changes, there are a few other noteworthy things I've done here:
- Used `-std=c11` for compiling the code, in order to get access to `_Static_assert` and `stdatomic.h`. These things aren't *strictly* necessary, but they're very nice tools to have at my disposal.
- Added AES and SHA256 software implementations by Brad Conte. We can evaluate if there's a better approach / better software implementations to use.

Copying the current version of the in-DRAM encryption writeup below:

---

# DRAM encryption scheme

## Paging in/out

Userland (enclave) memory managed by the Keystone runtime uses a paging scheme to ensure that the limited amount of on-chip memory will suffice for a large enclave. This is similar to swap space on a consumer PC, except the backing store is off-chip DRAM instead of a spinning disk.

Whenever a page fault occurs, this paging mechanism will evict a page from on-chip memory to the backing store, and optionally load a demanded page to the same physical address. In pseudocode:

```python
swap_page(backing_addr, onchip_addr, swap):
    if swap:
        tmp = copy_page(backing_addr)
    backing_addr = copy_page(onchip_addr)
    if swap:
        onchip_addr = copy_page(tmp)
```

## Motivation

We would like to augment this demand paging mechanism with strong encryption so that:

- Enclave pages in memory cannot be deciphered by an attacker with physical access to DRAM.
- Stale enclave pages cannot be "replayed" by overwriting new ones in DRAM.
- Tampering with off-chip pages is detected and results in safe termination of the enclave.

## Implementation

### AES-256 (CTR Mode) 

Read-security can be accomplished by inserting calls to AES-256 (CTR Mode) cryptography routines while swapping pages. Here, the simplest IV to use would be a randomly-generated 32 byte value, stored in off-chip memory. For indecipherability of the data only, it is acceptable to store IVs in off-chip memory as an attacker reading the IV will still be unable to decode any page contents without the encryption key, which is generated randomly on initialization and always kept in on-chip memory.

```python
swap_page(backing_addr, onchip_addr, swap):
    if swap:
        tmp = copy_page(backing_addr)
    
    iv = random(32)
    prev_iv = iv_store.swap(iv, key=backing_addr)
    
    backing_addr = aes_encrypt_page(onchip_addr, boot_key, iv)
    if swap:
        onchip_addr = aes_decrypt_page(tmp, boot_key, prev_iv)
```

### Incrementing pageout counter

To prevent replay attacks, an attacker must be prevented from reloading both a stale page's contents to the page store, and a stale IV from the IV store. So if we can prevent the replay of any page's IV, the attacker will be unable to replay the page swap and obtain decipherable results.

The simplest solution to protecting these IVs would be to place the IV store inside on-chip memory, where attackers are unable to access it. Unfortunately, this becomes space prohibitive; with an off-chip backing store of potentially tens of thousands of pages, this IV store would occupy hundreds of kilobytes of precious secure memory.

The basic requirement for an AES-CTR scheme is that no key/IV pair is ever reused. Using this requirement, we first recognize that it is unnecessary to generate completely random IVs. It suffices to implement an incrementing counter, per physical page of backing store. This 64-bit counter is incremented each time there is a pageout to DRAM. The IV becomes the value of this counter, shifted left to occupy bytes [15:8] of the 32-byte IV. This shift is to prevent overlapping IV values for consecutive pageouts, as in AES the IV is automatically incremented for each 16-byte block in the input buffer.

This counter store, now occupying considerably less space compared to the original IV store, is still too large for on-chip memory. For an inefficient solution, we can compute a secure hash of the counter store on each page swap, and check it against a hash stored in on-chip memory.


```python
swap_page(backing_addr, onchip_addr, swap):
    if swap:
        tmp = copy_page(backing_addr)
    
    prev_ctr, prev_hash = ctr_store.hashed_query(key=backing_addr)
    next_ctr = prev_ctr + 1
    new_hash = ctr_store.hashed_store(key=backing_addr, next_ctr)
    
    assert(prev_hash == stored_hash)
    stored_hash = new_hash
    
    iv = (int256)next_ctr << 64
    prev_iv = (int256)prev_ctr << 64
    
    backing_addr = aes_encrypt_page(onchip_addr, boot_key, iv)
    if swap:
        onchip_addr = aes_decrypt_page(tmp, boot_key, prev_iv)
```

### Merkle tree

In order to both verify the validity of the decrypted memory and more efficiently verify the counter store, we use a Merkle Tree data structure. The interface for this tree has two functions:

```
merk_insert(root, key, hash)
merk_verify(root, key, hash) -> bool
```

We modify the existing swap_page function to verify an existing Merkle tree entry on decryption, and then insert a new merkle tree entry after encryption:

```python
swap_page(backing_addr, onchip_addr, swap):
    if swap:
        tmp = copy_page(backing_addr)
    
    prev_ctr, prev_hash = ctr_store.query(key=backing_addr)
    next_ctr = prev_ctr + 1
    new_hash = ctr_store.store(key=backing_addr, next_ctr)
    
    iv = (int256)next_ctr << 64
    prev_iv = (int256)prev_ctr << 64
    
    # Hash the decrypted data being swapped out
    new_hash = sha256([page_mem(onchip_addr), next_ctr])
    backing_addr = aes_encrypt_page(onchip_addr, boot_key, iv)
    
    if swap:
        onchip_addr = aes_decrypt_page(tmp, boot_key, prev_iv)
        # Hash the decrypted data that was swapped in
        prev_hash = sha256([page_mem(onchip_addr), prev_ctr])
        ok = merk_verify(merk_root, backing_addr, prev_hash)
        assert(ok)
    
    merk_insert(merk_root, onchip_addr, prev_hash)
    assert(ok)
```

Of note is that the hash being used for verification is formed from both the page contents and the page counter. This ensures that no replay attacks are possible, for either page or counter, and that the two values must be kept in sync in memory.

Generally, the Merkle tree is implemented such that all data is read completely into memory before checks are performed, and not reloaded after such checks are performed. This protects the security of the system from race conditions.