### PR TITLE
Embed eyrie-rt options into elf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ifndef KEYSTONE_SDK_DIR
 endif
 
 CC = riscv64-unknown-linux-gnu-gcc
+OBJCOPY = riscv64-unknown-linux-gnu-objcopy
 CFLAGS = -Wall -Werror -fPIC -fno-builtin $(OPTIONS_FLAGS)
 SRCS = boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c
 ASM_SRCS = entry.S
@@ -43,6 +44,7 @@ copy: $(RUNTIME) $(DISK_IMAGE)
 
 $(RUNTIME): $(ASM_OBJS) $(OBJS) $(SDK_EDGE_LIB) $(TMPLIB)
 	$(LINK) $(LINKFLAGS) -o $@ $^ -T runtime.lds
+	$(OBJCOPY) --add-section .options_log=.options_log --set-section-flags .options_log=noload,readonly $(RUNTIME)
 
 $(ASM_OBJS): $(ASM_SRCS)
 	$(CC) $(CFLAGS) -c $<

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 
 EYRIE_SOURCE_DIR=`dirname $0`
 REQ_PLUGINS=${@:1}
+OPTIONS_LOG=${EYRIE_SOURCE_DIR}/.options_log
 
 # Build known plugins
 declare -A PLUGINS
@@ -16,11 +17,14 @@ PLUGINS[debug]="-DDEBUG "
 
 OPTIONS_FLAGS=
 
+rm -f $OPTIONS_LOG
+
 for plugin in $REQ_PLUGINS; do
     if [[ ! ${PLUGINS[$plugin]+_} ]]; then
         echo "Unknown Eyrie plugin '$plugin'. Skipping"
     else
         OPTIONS_FLAGS+=${PLUGINS[$plugin]}
+        echo -n "$plugin " >> $OPTIONS_LOG
     fi
 done
 


### PR DESCRIPTION
Added embedding the exact eyrie options passed to build.sh into an extra elf section.
Can be read via `riscv64-unknown-elf-readelf -p .options_log eyrie-rt`
Useful to sanity check what options some given eyrie-rt was actually built with.