### PR TITLE
Fix build.sh to build with no arguments, fix Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 eyrie-rt
+.options_log
 *.o

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,18 @@ addons:
 before_install:
   - ./.fast-setup.sh
   - git clone "https://github.com/keystone-enclave/keystone-sdk"
-  - cd keystone-sdk
+  - pushd keystone-sdk
   - make
+  - popd
 
 jobs:
   include:
     - stage: default build
       script:
-        - make
+        - ./build.sh 
     - stage: USE_FREEMEM
       script:
-        - OPTIONS_FLAGS="-DUSE_FREEMEM" make
+        - ./build.sh freemem
     - stage: USE_PAGING
       script:
-        - OPTIONS_FLAGS="-DUSE_FREEMEM -DUSE_PAGING" make
+        - ./build.sh paging

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ PLUGINS[debug]="-DDEBUG "
 
 OPTIONS_FLAGS=
 
-rm -f $OPTIONS_LOG
+echo > $OPTIONS_LOG
 
 for plugin in $REQ_PLUGINS; do
     if [[ ! ${PLUGINS[$plugin]+_} ]]; then


### PR DESCRIPTION
Turns out Travis doesn't automatically return to the base directory after `before_install`. Whoops!