### PR TITLE
Add simple test runner for utility modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 eyrie-rt
 .options_log
 *.o
+obj/
+.exists

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/cmocka"]
+	path = test/cmocka
+	url = https://gitlab.com/cmocka/cmocka.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
     - git
 
 before_install:
+  - git submodule update --init --recursive --depth=1
   - ./.fast-setup.sh
   - git clone "https://github.com/keystone-enclave/keystone-sdk"
   - pushd keystone-sdk
@@ -47,7 +48,7 @@ jobs:
         - FORMAT_COMMIT_START=$(echo $TRAVIS_COMMIT_RANGE | cut -d. -f1)
         - echo "Formatting from $FORMAT_COMMIT_START"
         - git clang-format --diff $FORMAT_COMMIT_START | tee .format-diff
-        - \[ "$(cat .format-diff)" = "no modified files to format" \]
+        - \[ "$(cat .format-diff)" = "no modified files to format" \] || \[ "$(cat .format-diff)" = "clang-format did not modify any files" \]
     - stage: default build
       script:
         - ./build.sh 
@@ -57,3 +58,11 @@ jobs:
     - stage: USE_PAGING
       script:
         - ./build.sh paging
+    - stage: test
+      script:
+        - mkdir -p obj/test
+        - pushd obj/test
+        - cmake ../../test
+        - make
+        - ctest -VV || ( cat obj/test/Testing/Temporary/LastTest.log && false )
+        - popd

--- a/README.md
+++ b/README.md
@@ -4,6 +4,36 @@ Eyrie only builds as part of the Keystone [sdk](https://github.com/keystone-encl
 
 We strongly encourage using the top-level [Keystone](https://github.com/keystone-enclave/keystone) build process.
 
-# Build options
+# Building
+
+## Building the Eyrie Runtime
+
+Make sure you've properly set the environment variable `KEYSTONE_SDK_DIR` to point to the Keystone SDK installation path.
+
+Then, run `./build.sh [features]`.
+
+## Running the tests
+
+Make sure you checked out all submodules with `git submodule update --init`.
+
+Then, run `make test`.
+
+If a test fails and you'd like more detail, enter into `obj/test` and run the binary for the failed test. e.g. if `test_string` fails, run `obj/test/test_string`.
+
+## Build options
 
 See the sdk Makefile for feature selection.
+
+# Contributing
+
+The Eyrie Runtime is licensed under the 3-clause BSD license. See LICENSE for more details.
+
+Before submitting a pull request to GitHub, make sure you format your code first. You can use one of the following options:
+
+```sh
+git clang-format HEAD   # Formats any staged changes
+git clang-format HEAD^  # Formats a single commit, and the staged changes
+git clang-format HEAD~5 # Formats the past 5 commits (for example), and the staged changes
+```
+
+It's recommended that you use always the first option to format staged changes before committing, to keep changes clean.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.0)
+project(eyrie_test)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmocka/cmake/Modules")
+
+set(WITH_EXAMPLES false)
+add_subdirectory(cmocka)
+
+include(AddCMockaTest)
+enable_testing()
+
+add_cmocka_test(test_string SOURCES string.c COMPILE_OPTIONS -I${CMAKE_BINARY_DIR}/cmocka/include LINK_LIBRARIES cmocka)

--- a/test/mock.h
+++ b/test/mock.h
@@ -1,0 +1,7 @@
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+
+#pragma once
+
+#include <cmocka.h>

--- a/test/string.c
+++ b/test/string.c
@@ -1,0 +1,45 @@
+#include "../string.c"
+
+#include "mock.h"
+
+static void
+test_unaligned_memcpy(void** ctx) {
+  char src[32];
+  char dst[32] = {};
+  char acc     = 1;
+  // populate acc
+  for (int i = 0; i < 32; i++) {
+    acc *= 251;
+    src[i] = acc;
+  }
+  // do the memcpy
+  memcpy(dst + 1, src + 3, 29);
+  // check
+  assert_int_equal(dst[0], 0);
+  assert_int_equal(dst[30], 0);
+  assert_int_equal(dst[31], 0);
+  for (int i = 0; i < 29; i++) {
+    assert_int_equal(dst[i + 1], src[i + 3]);
+  }
+}
+
+static void
+test_unaligned_memset(void** ctx) {
+  char dst[32] = {};
+  memset(dst + 1, 'A', 29);
+  assert_int_equal(dst[0], 0);
+  assert_int_equal(dst[30], 0);
+  assert_int_equal(dst[31], 0);
+  for (int i = 0; i < 29; i++) {
+    assert_int_equal(dst[i + 1], 'A');
+  }
+}
+
+int
+main() {
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_unaligned_memcpy),
+      cmocka_unit_test(test_unaligned_memset),
+  };
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This adds a new macro to register a test, and a test runner.
These tests can be located in-source, and as such are able to access
static data.

This commit also changes the Makefile to separate target object files
from test object files.

Some notes:
- Order of test execution is unspecified
- All global data persists within the test run

This adds a couple tests to string.c to get started.