### PR TITLE
[Secure Paging] Build with std=c11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 CC = riscv64-unknown-linux-gnu-gcc
 OBJCOPY = riscv64-unknown-linux-gnu-objcopy
-CFLAGS = -Wall -Werror -fPIC -fno-builtin $(OPTIONS_FLAGS)
+CFLAGS = -Wall -Werror -fPIC -fno-builtin -std=c11 -g $(OPTIONS_FLAGS)
 SRCS = boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c
 ASM_SRCS = entry.S
 RUNTIME = eyrie-rt

--- a/rt_util.c
+++ b/rt_util.c
@@ -47,7 +47,7 @@ void not_implemented_fatal(struct encl_ctx* ctx){
 #endif
 
     // Bail to m-mode
-    asm volatile ("csrr a0, scause\r\nli a7, 1111\r\n ecall");
+    __asm__ volatile("csrr a0, scause\r\nli a7, 1111\r\n ecall");
 
     return;
 }
@@ -71,5 +71,5 @@ void rt_page_fault(struct encl_ctx* ctx)
 
 void tlb_flush(void)
 {
-  asm volatile ("fence.i\t\nsfence.vma\t\n");
+  __asm__ volatile("fence.i\t\nsfence.vma\t\n");
 }

--- a/sbi.h
+++ b/sbi.h
@@ -28,17 +28,18 @@
 #define SM_MULTIMEM_CALL_GET_SIZE 0x01
 #define SM_MULTIMEM_CALL_GET_ADDR 0x02
 
-#define SBI_CALL(___which, ___arg0, ___arg1, ___arg2) ({			\
-	register uintptr_t a0 asm ("a0") = (uintptr_t)(___arg0);	\
-	register uintptr_t a1 asm ("a1") = (uintptr_t)(___arg1);	\
-	register uintptr_t a2 asm ("a2") = (uintptr_t)(___arg2);	\
-	register uintptr_t a7 asm ("a7") = (uintptr_t)(___which);	\
-	asm volatile ("ecall"					\
-		      : "+r" (a0)				\
-		      : "r" (a1), "r" (a2), "r" (a7)		\
-		      : "memory");				\
-	a0;							\
-})
+#define SBI_CALL(___which, ___arg0, ___arg1, ___arg2)            \
+  ({                                                             \
+    register uintptr_t a0 __asm__("a0") = (uintptr_t)(___arg0);  \
+    register uintptr_t a1 __asm__("a1") = (uintptr_t)(___arg1);  \
+    register uintptr_t a2 __asm__("a2") = (uintptr_t)(___arg2);  \
+    register uintptr_t a7 __asm__("a7") = (uintptr_t)(___which); \
+    __asm__ volatile("ecall"                                     \
+                     : "+r"(a0)                                  \
+                     : "r"(a1), "r"(a2), "r"(a7)                 \
+                     : "memory");                                \
+    a0;                                                          \
+  })
 
 /* Lazy implementations until SBI is finalized */
 #define SBI_CALL_0(___which) SBI_CALL(___which, 0, 0, 0)

--- a/tmplib/uaccess.h
+++ b/tmplib/uaccess.h
@@ -24,11 +24,12 @@ copy_from_user(void *to, const void *from, unsigned long n)
 }
 
 /* Dangerous feature needed for a few things (ex: strlen on usermemory) */
-#define ALLOW_USER_ACCESS(x) { \
-  unsigned long tmp_storage; \
-  asm volatile ("li %0, %1" : "=r" (tmp_storage) : "i" (SR_SUM));       \
-  asm volatile ("csrs sstatus, %0" : "=r" (tmp_storage)); \
-  (x);                                                    \
-  asm volatile ("csrc sstatus, %0" : "=r" (tmp_storage)); \
+#define ALLOW_USER_ACCESS(x)                                         \
+  {                                                                  \
+    unsigned long tmp_storage;                                       \
+    __asm__ volatile("li %0, %1" : "=r"(tmp_storage) : "i"(SR_SUM)); \
+    __asm__ volatile("csrs sstatus, %0" : "=r"(tmp_storage));        \
+    (x);                                                             \
+    __asm__ volatile("csrc sstatus, %0" : "=r"(tmp_storage));        \
   }
 #endif /* _UACCESS_H_ */


### PR DESCRIPTION
Also fixes some inline asm syntax errors that come up from the switch.

Prerequisite to Secure Paging (#27) as that uses C11's `static_assert`.