### PR TITLE
[Secure Paging] Move SBI calls behind function calls to allow mocking them in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 CC = riscv64-unknown-linux-gnu-gcc
 OBJCOPY = riscv64-unknown-linux-gnu-objcopy
 CFLAGS = -Wall -Werror -fPIC -fno-builtin -std=c11 -g $(OPTIONS_FLAGS)
-SRCS = aes.c sha256.c boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c
+SRCS = aes.c sha256.c boot.c interrupt.c printf.c syscall.c string.c linux_wrap.c io_wrap.c rt_util.c mm.c env.c freemem.c paging.c sbi.c
 ASM_SRCS = entry.S
 RUNTIME = eyrie-rt
 LINK = $(CROSS_COMPILE)ld

--- a/mm.h
+++ b/mm.h
@@ -1,8 +1,9 @@
 #ifndef _MM_H_
 #define _MM_H_
-#include <stdint.h>
 #include <stddef.h>
-#include "vm.h"
+#include <stdint.h>
+
+#include "vm_defs.h"
 
 uintptr_t translate(uintptr_t va);
 pte* pte_of_va(uintptr_t va);

--- a/paging.c
+++ b/paging.c
@@ -6,6 +6,8 @@
 
 #include "paging.h"
 
+#include "vm.h"
+
 uintptr_t paging_backing_storage_addr;
 uintptr_t paging_backing_storage_size;
 uintptr_t paging_next_backing_page_offset;

--- a/paging.h
+++ b/paging.h
@@ -4,14 +4,15 @@
 #define __PAGING_H__
 
 #include <stdint.h>
+
+#include "common.h"
+#include "freemem.h"
+#include "mm.h"
 #include "printf.h"
 #include "regs.h"
-#include "common.h"
-#include "vm.h"
-#include "mm.h"
-#include "freemem.h"
-#include "string.h"
 #include "rt_util.h"
+#include "string.h"
+#include "vm_defs.h"
 
 unsigned int paging_remaining_pages(void);
 void init_paging(uintptr_t user_pa_start, uintptr_t user_pa_end);

--- a/printf.c
+++ b/printf.c
@@ -71,11 +71,6 @@
 #define FLAGS_LONG_LONG (1U <<  9U)
 #define FLAGS_PRECISION (1U << 10U)
 
-void _putchar(char character)
-{
-  SBI_CALL_1(SBI_CONSOLE_PUTCHAR, character);
-}
-
 // output function type
 typedef void (*out_fct_type)(char character, void* buffer, size_t idx, size_t maxlen);
 
@@ -108,7 +103,7 @@ static inline void _out_char(char character, void* buffer, size_t idx, size_t ma
 {
   (void)buffer; (void)idx; (void)maxlen;
   if (character) {
-    _putchar(character);
+    sbi_putchar(character);
   }
 }
 

--- a/rt_util.h
+++ b/rt_util.h
@@ -1,9 +1,10 @@
 #ifndef _RT_UTIL_H_
 #define _RT_UTIL_H_
 
-#include "regs.h"
 #include <stddef.h>
-#include "vm.h"
+
+#include "regs.h"
+#include "vm_defs.h"
 
 #define FATAL_DEBUG
 

--- a/sbi.c
+++ b/sbi.c
@@ -1,0 +1,75 @@
+#include "sbi.h"
+
+#include "vm_defs.h"
+
+#define SBI_CALL(___which, ___arg0, ___arg1, ___arg2)            \
+  ({                                                             \
+    register uintptr_t a0 __asm__("a0") = (uintptr_t)(___arg0);  \
+    register uintptr_t a1 __asm__("a1") = (uintptr_t)(___arg1);  \
+    register uintptr_t a2 __asm__("a2") = (uintptr_t)(___arg2);  \
+    register uintptr_t a7 __asm__("a7") = (uintptr_t)(___which); \
+    __asm__ volatile("ecall"                                     \
+                     : "+r"(a0)                                  \
+                     : "r"(a1), "r"(a2), "r"(a7)                 \
+                     : "memory");                                \
+    a0;                                                          \
+  })
+
+/* Lazy implementations until SBI is finalized */
+#define SBI_CALL_0(___which) SBI_CALL(___which, 0, 0, 0)
+#define SBI_CALL_1(___which, ___arg0) SBI_CALL(___which, ___arg0, 0, 0)
+#define SBI_CALL_2(___which, ___arg0, ___arg1) \
+  SBI_CALL(___which, ___arg0, ___arg1, 0)
+#define SBI_CALL_3(___which, ___arg0, ___arg1, ___arg2) \
+  SBI_CALL(___which, ___arg0, ___arg1, ___arg2)
+
+void
+sbi_putchar(char character) {
+  SBI_CALL_1(SBI_CONSOLE_PUTCHAR, character);
+}
+
+void
+sbi_set_timer(uint64_t stime_value) {
+#if __riscv_xlen == 32
+  SBI_CALL_2(SBI_SET_TIMER, stime_value, stime_value >> 32);
+#else
+  SBI_CALL_1(SBI_SET_TIMER, stime_value);
+#endif
+}
+
+uintptr_t
+sbi_stop_enclave(uint64_t request) {
+  return SBI_CALL_1(SBI_SM_STOP_ENCLAVE, request);
+}
+
+void
+sbi_exit_enclave(uint64_t retval) {
+  SBI_CALL_1(SBI_SM_EXIT_ENCLAVE, retval);
+}
+
+uintptr_t
+sbi_random() {
+  return SBI_CALL_0(SBI_SM_RANDOM);
+}
+
+uintptr_t
+sbi_query_multimem() {
+  return SBI_CALL_2(
+      SBI_SM_CALL_PLUGIN, SM_MULTIMEM_PLUGIN_ID, SM_MULTIMEM_CALL_GET_SIZE);
+}
+
+uintptr_t
+sbi_query_multimem_addr() {
+  return SBI_CALL_2(
+      SBI_SM_CALL_PLUGIN, SM_MULTIMEM_PLUGIN_ID, SM_MULTIMEM_CALL_GET_ADDR);
+}
+
+uintptr_t
+sbi_attest_enclave(void* report, void* buf, uintptr_t len) {
+  return SBI_CALL_3(SBI_SM_ATTEST_ENCLAVE, report, buf, len);
+}
+
+uintptr_t
+sbi_get_sealing_key(uintptr_t key_struct, uintptr_t key_ident, uintptr_t len) {
+  return SBI_CALL_3(SBI_SM_GET_SEALING_KEY, key_struct, key_ident, len);
+}

--- a/sbi.h
+++ b/sbi.h
@@ -28,55 +28,23 @@
 #define SM_MULTIMEM_CALL_GET_SIZE 0x01
 #define SM_MULTIMEM_CALL_GET_ADDR 0x02
 
-#define SBI_CALL(___which, ___arg0, ___arg1, ___arg2)            \
-  ({                                                             \
-    register uintptr_t a0 __asm__("a0") = (uintptr_t)(___arg0);  \
-    register uintptr_t a1 __asm__("a1") = (uintptr_t)(___arg1);  \
-    register uintptr_t a2 __asm__("a2") = (uintptr_t)(___arg2);  \
-    register uintptr_t a7 __asm__("a7") = (uintptr_t)(___which); \
-    __asm__ volatile("ecall"                                     \
-                     : "+r"(a0)                                  \
-                     : "r"(a1), "r"(a2), "r"(a7)                 \
-                     : "memory");                                \
-    a0;                                                          \
-  })
+void
+sbi_putchar(char c);
+void
+sbi_set_timer(uint64_t stime_value);
+uintptr_t
+sbi_stop_enclave(uint64_t request);
+void
+sbi_exit_enclave(uint64_t retval);
+uintptr_t
+sbi_random();
+uintptr_t
+sbi_query_multimem();
+uintptr_t
+sbi_query_multimem_addr();
+uintptr_t
+sbi_attest_enclave(void* report, void* buf, uintptr_t len);
+uintptr_t
+sbi_get_sealing_key(uintptr_t key_struct, uintptr_t key_ident, uintptr_t len);
 
-/* Lazy implementations until SBI is finalized */
-#define SBI_CALL_0(___which) SBI_CALL(___which, 0, 0, 0)
-#define SBI_CALL_1(___which, ___arg0) SBI_CALL(___which, ___arg0, 0, 0)
-#define SBI_CALL_2(___which, ___arg0, ___arg1) SBI_CALL(___which, ___arg0, ___arg1, 0)
-#define SBI_CALL_3(___which, ___arg0, ___arg1, ___arg2) SBI_CALL(___which, ___arg0, ___arg1, ___arg2)
-
-static inline void sbi_set_timer(uint64_t stime_value){
-#if __riscv_xlen == 32
-	SBI_CALL_2(SBI_SET_TIMER, stime_value, stime_value >> 32);
-#else
-	SBI_CALL_1(SBI_SET_TIMER, stime_value);
-#endif
-}
-
-static inline void sbi_stop_enclave(uint64_t request)
-{
-  SBI_CALL_1(SBI_SM_STOP_ENCLAVE, request);
-}
-
-static inline void sbi_exit_enclave(uint64_t retval)
-{
-  SBI_CALL_1(SBI_SM_EXIT_ENCLAVE, retval);
-}
-
-static inline uintptr_t sbi_random()
-{
-  return SBI_CALL_0(SBI_SM_RANDOM);
-}
-
-static inline uintptr_t sbi_query_multimem()
-{
-  return SBI_CALL_2(SBI_SM_CALL_PLUGIN, SM_MULTIMEM_PLUGIN_ID, SM_MULTIMEM_CALL_GET_SIZE);
-}
-
-static inline uintptr_t sbi_query_multimem_addr()
-{
-  return SBI_CALL_2(SBI_SM_CALL_PLUGIN, SM_MULTIMEM_PLUGIN_ID, SM_MULTIMEM_CALL_GET_ADDR);
-}
 #endif

--- a/syscall.c
+++ b/syscall.c
@@ -38,7 +38,7 @@ uintptr_t dispatch_edgecall_syscall(struct edge_syscall* syscall_data_ptr, size_
     return -1;
   }
 
-  ret = SBI_CALL_1(SBI_SM_STOP_ENCLAVE, 1);
+  ret = sbi_stop_enclave(1);
 
   if (ret != 0) {
     return -1;
@@ -87,7 +87,7 @@ uintptr_t dispatch_edgecall_ocall( unsigned long call_id,
     goto ocall_error;
   }
 
-  ret = SBI_CALL_1(SBI_SM_STOP_ENCLAVE, 1);
+  ret = sbi_stop_enclave(1);
 
   if (ret != 0) {
     goto ocall_error;
@@ -161,7 +161,7 @@ void handle_syscall(struct encl_ctx* ctx)
 
   switch (n) {
   case(RUNTIME_SYSCALL_EXIT):
-    SBI_CALL_1(SBI_SM_EXIT_ENCLAVE, arg0);
+    sbi_exit_enclave(arg0);
     break;
   case(RUNTIME_SYSCALL_OCALL):
     ret = dispatch_edgecall_ocall(arg0, (void*)arg1, arg2, (void*)arg3, arg4);
@@ -172,7 +172,7 @@ void handle_syscall(struct encl_ctx* ctx)
   case(RUNTIME_SYSCALL_ATTEST_ENCLAVE):;
     copy_from_user((void*)rt_copy_buffer_2, (void*)arg1, arg2);
 
-    ret = SBI_CALL_3(SBI_SM_ATTEST_ENCLAVE, rt_copy_buffer_1, rt_copy_buffer_2, arg2);
+    ret = sbi_attest_enclave(rt_copy_buffer_1, rt_copy_buffer_2, arg2);
 
     /* TODO we consistently don't have report size when we need it */
     copy_to_user((void*)arg0, (void*)rt_copy_buffer_1, 2048);
@@ -193,7 +193,7 @@ void handle_syscall(struct encl_ctx* ctx)
 
     copy_from_user(rt_copy_buffer_2, (void *)arg2, arg3);
 
-    ret = SBI_CALL_3(SBI_SM_GET_SEALING_KEY, buffer_1_pa, buffer_2_pa, arg3);
+    ret = sbi_get_sealing_key(buffer_1_pa, buffer_2_pa, arg3);
 
     if (!ret) {
       copy_to_user((void *)arg0, (void *)rt_copy_buffer_1, arg1);
@@ -250,7 +250,7 @@ void handle_syscall(struct encl_ctx* ctx)
   case(SYS_exit):
   case(SYS_exit_group):
     print_strace("[runtime] exit or exit_group (%lu)\r\n",n);
-    SBI_CALL_1(SBI_SM_EXIT_ENCLAVE, arg0);
+    sbi_exit_enclave(arg0);
     break;
 #endif /* LINUX_SYSCALL_WRAPPING */
 

--- a/vm.h
+++ b/vm.h
@@ -2,67 +2,10 @@
 #define __VM_H__
 
 #include <asm/csr.h>
-#include "printf.h"
+
 #include "common.h"
-
-#define BIT(n) (1ul << (n))
-#define MASK(n) (BIT(n)-1ul)
-#define IS_ALIGNED(n, b) (!((n) & MASK(b)))
-
-#if __riscv_xlen == 64
-#define RISCV_PT_INDEX_BITS 9
-#define RISCV_PT_LEVELS 3
-#elif __riscv_xlen == 32
-#define RISCV_PT_INDEX_BITS 10
-#define RISCV_PT_LEVELS 2
-#endif
-
-#define RISCV_PAGE_BITS 12
-#define RISCV_PAGE_SIZE (1<<RISCV_PAGE_BITS)
-#define RISCV_PAGE_OFFSET(addr) (addr % RISCV_PAGE_SIZE)
-#define RISCV_GET_PT_INDEX(addr, n)                                     \
-  (((addr) >> (((RISCV_PT_INDEX_BITS) * ((RISCV_PT_LEVELS) - (n))) + RISCV_PAGE_BITS)) \
-   & MASK(RISCV_PT_INDEX_BITS))
-#define RISCV_GET_LVL_PGSIZE_BITS(n) (((RISCV_PT_INDEX_BITS) * (RISCV_PT_LEVELS - (n))) + RISCV_PAGE_BITS)
-#define RISCV_GET_LVL_PGSIZE(n)      BIT(RISCV_GET_LVL_PGSIZE_BITS((n)))
-
-#define ROUND_UP(n, b) (((((n) - 1ul) >> (b)) + 1ul) << (b))
-#define ROUND_DOWN(n, b) (n & ~((2 << (b-1)) - 1))
-#define PAGE_DOWN(n) ROUND_DOWN(n, RISCV_PAGE_BITS)
-#define PAGE_UP(n) ROUND_UP(n, RISCV_PAGE_BITS)
-#define MEGAPAGE_DOWN(n) ROUND_DOWN(n, RISCV_GET_LVL_PGSIZE_BITS(2))
-#define MEGAPAGE_UP(n) ROUND_UP(n, RISCV_GET_LVL_PGSIZE_BITS(2))
-
-/* Starting address of the enclave memory */
-
-#if __riscv_xlen == 64
-#define EYRIE_LOAD_START        0xffffffff00000000
-#define EYRIE_PAGING_START      0xffffffff40000000
-#define EYRIE_UNTRUSTED_START   0xffffffff80000000
-#define EYRIE_USER_STACK_START  0x0000000040000000
-#define EYRIE_ANON_REGION_START 0x0000002000000000 // Arbitrary VA to start looking for large mappings
-#elif __riscv_xlen == 32
-#define EYRIE_LOAD_START        0xf0000000
-#define EYRIE_PAGING_START      0x40000000
-#define EYRIE_UNTRUSTED_START   0x80000000
-#define EYRIE_USER_STACK_START  0x40000000
-#define EYRIE_ANON_REGION_START 0x20000000 // Arbitrary VA to start looking for large mappings
-#endif
-
-#define EYRIE_ANON_REGION_END   EYRIE_LOAD_START
-#define EYRIE_USER_STACK_SIZE   0x20000
-#define EYRIE_USER_STACK_END    (EYRIE_USER_STACK_START - EYRIE_USER_STACK_SIZE)
-
-#define PTE_V     0x001 // Valid
-#define PTE_R     0x002 // Read
-#define PTE_W     0x004 // Write
-#define PTE_X     0x008 // Execute
-#define PTE_U     0x010 // User
-#define PTE_G     0x020 // Global
-#define PTE_A     0x040 // Accessed
-#define PTE_D     0x080 // Dirty
-#define PTE_FLAG_MASK 0x3ff
-#define PTE_PPN_SHIFT 10
+#include "printf.h"
+#include "vm_defs.h"
 
 extern void* rt_base;
 
@@ -90,7 +33,6 @@ static inline uintptr_t __pa(uintptr_t va)
   return (va - EYRIE_LOAD_START) + load_pa_start;
 }
 
-typedef uintptr_t pte;
 static inline pte pte_create(uintptr_t ppn, int type)
 {
   return (pte)((ppn << PTE_PPN_SHIFT) | PTE_V | (type & PTE_FLAG_MASK) );

--- a/vm_defs.h
+++ b/vm_defs.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#define BIT(n) (1ul << (n))
+#define MASK(n) (BIT(n) - 1ul)
+#define IS_ALIGNED(n, b) (!((n)&MASK(b)))
+
+#if __riscv_xlen == 64
+#define RISCV_PT_INDEX_BITS 9
+#define RISCV_PT_LEVELS 3
+#elif __riscv_xlen == 32
+#define RISCV_PT_INDEX_BITS 10
+#define RISCV_PT_LEVELS 2
+#endif
+
+#define RISCV_PAGE_BITS 12
+#define RISCV_PAGE_SIZE (1 << RISCV_PAGE_BITS)
+#define RISCV_PAGE_OFFSET(addr) (addr % RISCV_PAGE_SIZE)
+#define RISCV_GET_PT_INDEX(addr, n)                                            \
+  (((addr) >>                                                                  \
+    (((RISCV_PT_INDEX_BITS) * ((RISCV_PT_LEVELS) - (n))) + RISCV_PAGE_BITS)) & \
+   MASK(RISCV_PT_INDEX_BITS))
+#define RISCV_GET_LVL_PGSIZE_BITS(n) \
+  (((RISCV_PT_INDEX_BITS) * (RISCV_PT_LEVELS - (n))) + RISCV_PAGE_BITS)
+#define RISCV_GET_LVL_PGSIZE(n) BIT(RISCV_GET_LVL_PGSIZE_BITS((n)))
+
+#define ROUND_UP(n, b) (((((n)-1ul) >> (b)) + 1ul) << (b))
+#define ROUND_DOWN(n, b) (n & ~((2 << (b - 1)) - 1))
+#define PAGE_DOWN(n) ROUND_DOWN(n, RISCV_PAGE_BITS)
+#define PAGE_UP(n) ROUND_UP(n, RISCV_PAGE_BITS)
+#define MEGAPAGE_DOWN(n) ROUND_DOWN(n, RISCV_GET_LVL_PGSIZE_BITS(2))
+#define MEGAPAGE_UP(n) ROUND_UP(n, RISCV_GET_LVL_PGSIZE_BITS(2))
+
+/* Starting address of the enclave memory */
+
+#if __riscv_xlen == 64
+#define EYRIE_LOAD_START 0xffffffff00000000
+#define EYRIE_PAGING_START 0xffffffff40000000
+#define EYRIE_UNTRUSTED_START 0xffffffff80000000
+#define EYRIE_USER_STACK_START 0x0000000040000000
+#define EYRIE_ANON_REGION_START \
+  0x0000002000000000  // Arbitrary VA to start looking for large mappings
+#elif __riscv_xlen == 32
+#define EYRIE_LOAD_START 0xf0000000
+#define EYRIE_PAGING_START 0x40000000
+#define EYRIE_UNTRUSTED_START 0x80000000
+#define EYRIE_USER_STACK_START 0x40000000
+#define EYRIE_ANON_REGION_START \
+  0x20000000  // Arbitrary VA to start looking for large mappings
+#endif
+
+#define EYRIE_ANON_REGION_END EYRIE_LOAD_START
+#define EYRIE_USER_STACK_SIZE 0x20000
+#define EYRIE_USER_STACK_END (EYRIE_USER_STACK_START - EYRIE_USER_STACK_SIZE)
+
+#define PTE_V 0x001  // Valid
+#define PTE_R 0x002  // Read
+#define PTE_W 0x004  // Write
+#define PTE_X 0x008  // Execute
+#define PTE_U 0x010  // User
+#define PTE_G 0x020  // Global
+#define PTE_A 0x040  // Accessed
+#define PTE_D 0x080  // Dirty
+#define PTE_FLAG_MASK 0x3ff
+#define PTE_PPN_SHIFT 10
+
+typedef uintptr_t pte;


### PR DESCRIPTION
This also splits `vm.h` so that header files may include relevant definitions without pulling in `<asm/csr.h>`, which can't be included in tests.

Prerequisite to secure paging (#27)