### PR TITLE
Add benchmarking subsystem, measure runtime of Merkle tree ops

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,0 +1,13 @@
+CFLAGS := -I . -g -lm -O3
+
+.PHONY: bencher clean
+
+bencher:
+	$(CC) $(CFLAGS) \
+		-DUSE_FREEMEM -DUSE_PAGING -DUSE_PAGE_HASH -D__riscv_xlen=64 \
+		bencher.c merkle.c \
+		../merkle.c ../sha256.c \
+		-o $@
+
+clean:
+	rm -rf bencher

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,4 +1,4 @@
-CFLAGS := -I . -g -lm -O3
+CFLAGS := -I . -g -lm -O3 -Wall -Wextra
 
 .PHONY: bencher clean
 

--- a/bench/bencher.c
+++ b/bench/bencher.c
@@ -1,0 +1,252 @@
+#define _GNU_SOURCE
+
+#include "bencher.h"
+
+#include <argp.h>
+#include <assert.h>
+#include <math.h>
+#include <regex.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#define ERROR(...) fprintf(stderr, "[ERROR]  " __VA_ARGS__)
+
+static char*
+precise_time_str(double seconds) {
+  double precision;
+  const char* prec_name;
+  if (seconds < 1e-6) {
+    prec_name = "ns";
+    precision = 1e9;
+  } else if (seconds < 1e-3) {
+    prec_name = "us";
+    precision = 1e6;
+  } else if (seconds < 1) {
+    prec_name = "ms";
+    precision = 1e3;
+  } else {
+    prec_name = "s";
+    precision = 1;
+  }
+
+  char* out;
+  double adjusted = seconds * precision;
+  int err = asprintf(&out, "%f%s", trunc(adjusted * 1000) / 1000, prec_name);
+  return out;
+}
+
+static int
+measure_iters(
+    struct bench* bench, void* ctx, clock_t clocks, size_t chunk_size,
+    size_t* niters) {
+  int err;
+  size_t i = 0;
+
+  err = bench->init(ctx);
+  if (err) {
+    ERROR("Failed to initialize benchmark `%s`!\n", bench->name);
+    return err;
+  }
+
+  clock_t end_clock = clock() + clocks;
+  while (clock() < end_clock) {
+    for (size_t ci = 0; ci < chunk_size; ci++, i++) {
+      err = bench->iter(ctx);
+      if (err) {
+        ERROR(
+            "Failed to run iteration `%zu` of benchmark `%s`!\n", i,
+            bench->name);
+        return err;
+      }
+    }
+  }
+
+  assert(niters);
+  *niters = i;
+
+  err = bench->deinit(ctx);
+  if (err) {
+    ERROR("Failed to deinitialize benchmark `%s`!\n", bench->name);
+    return err;
+  }
+
+  return 0;
+}
+
+static int
+run_bench(
+    struct bench* bench, void* ctx, size_t nchunks, size_t chunk_size,
+    double* chunk_mean, double* chunk_std) {
+  int err;
+
+  err = bench->init(ctx);
+  if (err) {
+    ERROR("Failed to initialize benchmark `%s`!\n", bench->name);
+    return err;
+  }
+
+  clock_t chunk_start, chunk_end;
+  size_t chunk;
+  double mean, m2;
+
+  for (chunk = 0; chunk < nchunks; chunk++) {
+    chunk_start = clock();
+
+    for (size_t ci = 0; ci < chunk_size; ci++) {
+      err = bench->iter(ctx);
+      if (err) {
+        ERROR(
+            "Failed to run iteration `%zu` of benchmark `%s`!\n",
+            chunk * chunk_size + ci, bench->name);
+        return err;
+      }
+    }
+
+    chunk_end = clock();
+
+    double chunk_time = (double)(chunk_end - chunk_start) / CLOCKS_PER_SEC;
+    double delta      = chunk_time - mean;
+    mean += delta / (chunk + 1);
+    double delta2 = chunk_time - mean;
+    m2 += delta * delta2;
+  }
+
+  double variance = m2 / chunk;
+  assert(chunk_mean);
+  assert(chunk_std);
+  *chunk_mean = mean;
+  *chunk_std  = sqrt(variance);
+
+  err = bench->deinit(ctx);
+  if (err) {
+    ERROR("Failed to deinitialize benchmark `%s`!\n", bench->name);
+    return err;
+  }
+
+  return 0;
+}
+
+int
+run_benches(
+    struct bench_opts* opts, struct bench* benches, size_t nbenches,
+    void* ctx) {
+  regex_t filter;
+  if (opts->filter) {
+    int err = regcomp(&filter, opts->filter, REG_NOSUB);
+    if (err) {
+      ERROR("Bad regular expression: `%s`", opts->filter);
+      exit(err);
+    }
+  }
+
+  int measure_secs = 2;
+  int bench_secs   = 10;
+  assert(bench_secs % measure_secs == 0);
+  clock_t measure_clocks = measure_secs * CLOCKS_PER_SEC;
+
+#define CHECK_ERR(err, ...) \
+  if (err) {                \
+    putchar('\n');          \
+    ERROR(__VA_ARGS__);     \
+    exit(err);              \
+  }
+
+  for (size_t i = 0; i < nbenches; i++) {
+    struct bench* bench = &benches[i];
+    if (opts->filter && regexec(&filter, bench->name, 0, NULL, 0) != 0)
+      continue;
+
+    size_t measured_iters;
+    clock_t bench_time;
+    char* iter_time;
+    int err;
+
+    double single_time, _single_std;
+
+    if (opts->verbose)
+      printf("`%s`: Measuring single iteration... ", bench->name);
+    err = run_bench(bench, ctx, 1, 1, &single_time, &_single_std);
+    CHECK_ERR(err, "Failed to measure `%s`!\n", bench->name);
+
+    if (opts->verbose) {
+      iter_time = precise_time_str(single_time);
+      assert(iter_time);
+      printf("<%s\n", iter_time);
+      free(iter_time);
+    }
+
+    double approx_measured_iters = measure_secs / single_time;
+    size_t chunk_size            = pow(2.0, log2(approx_measured_iters) / 2);
+
+    if (opts->verbose)
+      printf(
+          "`%s`: Counting num iterations in %ds... ", bench->name,
+          measure_secs);
+    err =
+        measure_iters(bench, ctx, measure_clocks, chunk_size, &measured_iters);
+    CHECK_ERR(err, "Failed to measure `%s`!\n", bench->name);
+    if (opts->verbose) printf("%zu iterations.\n", measured_iters);
+
+    size_t bench_iters = (bench_secs / measure_secs) * measured_iters;
+    size_t nchunks     = bench_iters / chunk_size;
+
+    double chunk_mean, chunk_std;
+
+    printf(
+        "`%s`: Benchmarking %zux%zu iterations (~%ds)...\n", bench->name,
+        nchunks, chunk_size, bench_secs);
+    err = run_bench(bench, ctx, nchunks, chunk_size, &chunk_mean, &chunk_std);
+    CHECK_ERR(err, "Failed to measure `%s`!\n", bench->name);
+
+    iter_time = precise_time_str(chunk_mean);
+    printf("  Chunk runtime: %s", iter_time);
+    free(iter_time);
+
+    iter_time = precise_time_str(chunk_std);
+    printf(" (+/- %s)\n", iter_time);
+    free(iter_time);
+
+    iter_time = precise_time_str(chunk_mean / chunk_size);
+    printf("  Time/Iter: %s\n", iter_time);
+    free(iter_time);
+  }
+
+  return 0;
+}
+
+static error_t
+bench_arg_parser(int key, char* val, struct argp_state* state) {
+  struct bench_opts* opts = (struct bench_opts*)state->input;
+  switch (key) {
+    case 'f':
+      opts->filter = strdup(val);
+      break;
+    case 'v':
+      opts->verbose = true;
+      break;
+    default:
+      return ARGP_ERR_UNKNOWN;
+  }
+  return 0;
+}
+
+struct bench_opts
+bench_argp(int argc, char** argv) {
+  struct bench_opts opts = {};
+
+  struct argp_option argp_opts[] = {
+      {.name = "filter", .key = 'f', .arg = "REGEXP"},
+      {.name = "verbose", .key = 'v'},
+      {}};
+  struct argp argp = {
+      .options = argp_opts,
+      .parser  = bench_arg_parser,
+  };
+  error_t err = argp_parse(&argp, argc, argv, 0, 0, &opts);
+  if (err) {
+    ERROR("Can't parse arguments!\n");
+  }
+
+  return opts;
+}

--- a/bench/bencher.h
+++ b/bench/bencher.h
@@ -13,6 +13,8 @@ struct bench {
 struct bench_opts {
   bool verbose;
   char* filter;
+  int measure_secs;
+  int bench_secs;
 };
 
 struct bench_opts

--- a/bench/bencher.h
+++ b/bench/bencher.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+struct bench {
+  const char* name;
+  int (*init)(void* ctx);
+  int (*iter)(void* ctx);
+  int (*deinit)(void* ctx);
+};
+
+struct bench_opts {
+  bool verbose;
+  char* filter;
+};
+
+struct bench_opts
+bench_argp(int argc, char** argv);
+int
+run_benches(
+    struct bench_opts* opts, struct bench* benches, size_t nbenches, void* ctx);

--- a/bench/merkle.c
+++ b/bench/merkle.c
@@ -1,0 +1,129 @@
+#define _GNU_SOURCE
+
+#include <../merkle.h>
+#include <assert.h>
+#include <bencher.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+
+void
+sbi_exit_enclave(uintptr_t code) {
+  exit(code);
+}
+
+uintptr_t
+paging_alloc_backing_page() {
+  void* out = mmap(
+      NULL, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert(out != MAP_FAILED);
+  return (uintptr_t)out;
+}
+
+#define RAND_BOOK_LEN (4 * 1024 * 1024)
+
+typedef struct bench_ctx {
+  merkle_node_t root;
+  int* rand_book;
+  int rand_idx;
+} bench_ctx_t;
+
+void
+bench_ctx__init(bench_ctx_t* ctx) {
+  ctx->rand_book = (int*)malloc(sizeof(int) * RAND_BOOK_LEN);
+  for (int i = 0; i < RAND_BOOK_LEN; i++) {
+    ctx->rand_book[i] = rand();
+  }
+}
+
+int
+bench_insert__init(void* _ctx) {
+  bench_ctx_t* ctx = (bench_ctx_t*)_ctx;
+  ctx->rand_idx    = rand() % RAND_BOOK_LEN;
+  return 0;
+}
+
+int
+bench_insert__destroy(void* _ctx) {
+  bench_ctx_t* ctx = (bench_ctx_t*)_ctx;
+  merk_clear(&ctx->root);
+  return 0;
+}
+
+int
+bench_insert(void* _ctx) {
+  bench_ctx_t* ctx         = (bench_ctx_t*)_ctx;
+  const uint8_t* fake_hash = (uint8_t*)&ctx->rand_book[ctx->rand_idx / 2];
+  int err                  = merk_insert(&ctx->root, ctx->rand_idx, fake_hash);
+  ctx->rand_idx            = (ctx->rand_idx + 1) % RAND_BOOK_LEN;
+  return err;
+}
+
+int
+bench_insert_subset_128(void* _ctx) {
+  bench_ctx_t* ctx         = (bench_ctx_t*)_ctx;
+  const uint8_t* fake_hash = (uint8_t*)ctx->rand_book;
+  int err       = merk_insert(&ctx->root, ctx->rand_idx % 128, fake_hash);
+  ctx->rand_idx = (ctx->rand_idx + 1) % RAND_BOOK_LEN;
+  return err;
+}
+
+int
+bench_verify_128__init(void* _ctx) {
+  bench_ctx_t* ctx = (bench_ctx_t*)_ctx;
+  ctx->rand_idx    = rand() % RAND_BOOK_LEN;
+
+  for (int i = 0; i < 128; i++) {
+    int key          = ctx->rand_book[(ctx->rand_idx + i) % 128];
+    uint8_t hash[32] = {};
+    memcpy(hash, &key, sizeof key);
+    merk_insert(&ctx->root, key, hash);
+  }
+
+  ctx->rand_idx = rand() % RAND_BOOK_LEN;
+  return 0;
+}
+
+int
+bench_verify__destroy(void* _ctx) {
+  bench_ctx_t* ctx = (bench_ctx_t*)_ctx;
+  merk_clear(&ctx->root);
+  return 0;
+}
+
+int
+bench_verify_128(void* _ctx) {
+  bench_ctx_t* ctx = (bench_ctx_t*)_ctx;
+  int key          = ctx->rand_idx % 128;
+  uint8_t hash[32] = {};
+  memcpy(hash, &key, sizeof key);
+  int err       = merk_verify(&ctx->root, key, hash);
+  ctx->rand_idx = (ctx->rand_idx + 1) % RAND_BOOK_LEN;
+  return err;
+}
+
+int
+main(int argc, char** argv) {
+  srand(time(NULL));
+  bench_ctx_t ctx = {};
+  bench_ctx__init(&ctx);
+
+  struct bench benches[] = {
+      {.name   = "merkle tree insert",
+       .init   = bench_insert__init,
+       .deinit = bench_insert__destroy,
+       .iter   = bench_insert},
+      {.name   = "merkle tree insert subset (128)",
+       .init   = bench_insert__init,
+       .deinit = bench_insert__destroy,
+       .iter   = bench_insert_subset_128},
+      {.name   = "merkle tree verify (128)",
+       .init   = bench_insert__init,
+       .deinit = bench_insert__destroy,
+       .iter   = bench_insert_subset_128},
+  };
+  struct bench_opts opts = bench_argp(argc, argv);
+  run_benches(&opts, benches, sizeof(benches) / sizeof(struct bench), &ctx);
+}

--- a/merkle.c
+++ b/merkle.c
@@ -105,6 +105,20 @@ merk_free_node(merkle_node_t* node) {
   }
 }
 
+void
+merk_clear(merkle_node_t* root) {
+  if (root->left) {
+    merk_clear(root->left);
+    merk_free_node(root->left);
+    root->left = NULL;
+  }
+  if (root->right) {
+    merk_clear(root->right);
+    merk_free_node(root->right);
+    root->right = NULL;
+  }
+}
+
 static bool
 merk_verify_single_node(
     const merkle_node_t* node, const merkle_node_t* left,

--- a/merkle.h
+++ b/merkle.h
@@ -27,5 +27,7 @@ merk_insert(merkle_node_t* root, uintptr_t key, const uint8_t hash[32]);
 bool
 merk_verify(
     volatile merkle_node_t* root, uintptr_t key, const uint8_t hash_out[32]);
+void
+merk_clear(merkle_node_t* root);
 
 #endif


### PR DESCRIPTION
This adds a new subdirectory `bench/`, and a custom benchmark runner.