### PR TITLE
Fix accept syscall + epoll hack

### DIFF
--- a/io_wrap.c
+++ b/io_wrap.c
@@ -325,7 +325,9 @@ uintptr_t io_syscall_epoll_create(int size){
 
   sargs_SYS_epoll_create1 *args = (sargs_SYS_epoll_create1 *) edge_syscall->data;
 
-  args->size = size; 
+  // Since Linux 2.6.8, the size argument is ignored, but must be greater than
+  // zero. See https://man7.org/linux/man-pages/man2/epoll_create.2.html
+  args->size = 1024; 
 
   size_t totalsize = sizeof(struct edge_syscall) + sizeof(sargs_SYS_epoll_create1);
   ret = dispatch_edgecall_syscall(edge_syscall, totalsize);

--- a/net_wrap.c
+++ b/net_wrap.c
@@ -109,12 +109,12 @@ uintptr_t io_syscall_accept(int sockfd, uintptr_t addr, uintptr_t addrlen) {
 
   args->sockfd = sockfd; 
 
-  if(addrlen > sizeof(struct sockaddr_storage)) {
-    return ret; 
-  }
-
   copy_from_user(&args->addrlen, (void *) addrlen, sizeof(socklen_t));
   copy_from_user(&args->addr, (void *) addr, args->addrlen);
+
+  if(args->addrlen > sizeof(struct sockaddr_storage)) {
+    return ret; 
+  }
 
   size_t totalsize = sizeof(struct edge_syscall) + sizeof(sargs_SYS_accept);
   ret = dispatch_edgecall_syscall(edge_syscall, totalsize);


### PR DESCRIPTION
Fid the accept syscall and add a comment to epoll_create to explain the parameter passing.