### PR TITLE
Return randomness from the a1 register and not a0

### DIFF
--- a/sbi.c
+++ b/sbi.c
@@ -52,7 +52,9 @@ sbi_exit_enclave(uint64_t retval) {
 
 uintptr_t
 sbi_random() {
-  return SBI_CALL_0(SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE, SBI_SM_RANDOM);
+  SBI_CALL_0(SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE, SBI_SM_RANDOM);
+  register uintptr_t a1 __asm__("a1");
+  return a1;
 }
 
 uintptr_t


### PR DESCRIPTION
The `SBI_SM_RANDOM` call in the SM returns randomness in the `a1` register and not the `a0` register.
#### References: 
- https://github.com/keystone-enclave/sm/blob/master/src/sm-sbi-opensbi.c#L52
-  https://github.com/riscv-software-src/opensbi/blob/0d49c3bc1823df8bf229ba3ece8ca0a753f0622b/lib/sbi/sbi_ecall.c#L138