### PR TITLE
Specify input format for .options_log

### DIFF
--- a/sys/CMakeLists.txt
+++ b/sys/CMakeLists.txt
@@ -13,7 +13,8 @@ add_dependencies(eyrie-build rt_linkscript)
 
 add_custom_target(eyrie-rt ALL
         DEPENDS options_log eyrie-build
-        COMMAND ${CMAKE_OBJCOPY} --add-section .options_log=${CMAKE_BINARY_DIR}/.options_log
+        COMMAND ${CMAKE_OBJCOPY} -I binary
+            --add-section .options_log=${CMAKE_BINARY_DIR}/.options_log
             --set-section-flags .options_log=noload,readonly
             ${CMAKE_CURRENT_BINARY_DIR}/eyrie-build)
 


### PR DESCRIPTION
For some reason, the wrapping SDK build system does not know about the input format for the .options_log file. Therefore, we make this explicit by including a flag that specifies the options_log as raw binary. This has the desired effect of copying the configuration options into the final executable.

I also propose bumping the Eyrie release to v1.2.1 after this